### PR TITLE
Appveyor: Use newer Qt.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ build:
   verbosity: minimal
 
 install:
-  - set QTDIR=C:\Qt\5.9.2\msvc2017_64
+  - set QTDIR=C:\Qt\5.9\msvc2017_64
   - set PATH=%PATH%;%QTDIR%\bin
 
 build_script:


### PR DESCRIPTION
Qt was upgraded from 5.9.2 to 5.9.3; use a generic 5.9 version to last longer.