### PR TITLE
Scan for more metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 # Runtime files:
 SkauTan.sqlite
 SkauTan.bak.sqlite
+*.mp3
+

--- a/Database.h
+++ b/Database.h
@@ -76,6 +76,8 @@ public:
 	/** Returns all template items from all templates that have been marked as "favorite". */
 	std::vector<Template::ItemPtr> getFavoriteTemplateItems() const;
 
+	MetadataScanner & metadataScanner() { return m_MetadataScanner; }
+
 
 protected:
 

--- a/DlgSongs.h
+++ b/DlgSongs.h
@@ -71,18 +71,15 @@ private:
 
 private slots:
 
-	/** Opens up a folder picker, then adds the songs from the picked folder into the DB.
-	Signature needs to match QPushButton::clicked(bool). */
-	void chooseAddFolder(bool a_IsChecked);
-
-	/** Closes the dialog.
-	Signature needs to match QPushButton::clicked(bool). */
-	void closeByButton(bool a_IsChecked);
+	/** Opens up a folder picker, then adds the songs from the picked folder into the DB. */
+	void chooseAddFolder();
 
 	/** Adds the selected songs into the playlist.
-	Emits the addSong() signal for each selected song.
-	Signature needs to match QPushButton::clicked(bool). */
-	void addSelectedToPlaylist(bool a_IsChecked);
+	Emits the addSongToPlaylist() signal for each selected song. */
+	void addSelectedToPlaylist();
+
+	/** Queues the selected songs for metadata rescan. */
+	void rescanMetadata();
 
 	/** Emitted by the model after the user edits a song. */
 	void modelSongEdited(Song * a_Song);

--- a/DlgSongs.ui
+++ b/DlgSongs.ui
@@ -76,6 +76,13 @@
       </widget>
      </item>
      <item>
+      <widget class="QPushButton" name="btnRescanMetadata">
+       <property name="text">
+        <string>&amp;Rescan metadata</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <spacer name="horizontalSpacer_2">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>

--- a/MetadataScanner.cpp
+++ b/MetadataScanner.cpp
@@ -92,17 +92,16 @@ protected:
 			return;
 		}
 
-		// Auto-detect genre from the folder name:
+		// Auto-detect genre from the parent folders names:
 		if (!m_Song->genre().isValid())
 		{
-			auto idxPrevSlash = a_FileName.lastIndexOf('/', idxLastSlash - 1);
-			if (idxPrevSlash >= 0)
+			auto parents = a_FileName.split('/', QString::SkipEmptyParts);
+			for (const auto & p: parents)
 			{
-				auto lastFolder = a_FileName.mid(idxPrevSlash + 1, idxLastSlash - idxPrevSlash - 1);
-				auto genre = folderNameToGenre(lastFolder);
-				if (!genre.isEmpty())
+				tryMatchGenreMPM(p);
+				if (m_Song->genre().isValid())  // Did we assign a genre?
 				{
-					m_Song->setGenre(genre);
+					break;
 				}
 			}
 		}
@@ -135,35 +134,6 @@ protected:
 				m_Song->setTitle(fileBareName.mid(idxSeparator + 3).trimmed());
 			}
 		}
-	}
-
-
-	/** Returns the song genre that is usually contained in a folder of the specified name.
-	Returns empty string if no such song genre is known. */
-	static QString folderNameToGenre(const QString & a_FolderName)
-	{
-		static const std::map<QString, QString> genreMap =
-		{
-			{ "waltz",     "SW" },
-			{ "tango",     "TG" },
-			{ "valčík",    "VW" },
-			{ "slowfox",   "SF" },
-			{ "quickstep", "QS" },
-			{ "samba",     "SB" },
-			{ "chacha",    "CH" },
-			{ "rumba",     "RB" },
-			{ "paso",      "PD" },
-			{ "pasodoble", "PD" },
-			{ "jive",      "JI" },
-			{ "blues",     "BL" },
-			{ "polka",     "PO" },
-		};
-		auto itr = genreMap.find(a_FolderName.toLower());
-		if (itr == genreMap.end())
-		{
-			return QString();
-		}
-		return itr->second;
 	}
 
 

--- a/MetadataScanner.cpp
+++ b/MetadataScanner.cpp
@@ -72,6 +72,13 @@ protected:
 		{
 			m_Song->setTitle(QString::fromStdString(tag->title().to8Bit(true)));
 		}
+		auto comment = QString::fromStdString(tag->comment().to8Bit(true));
+		comment = tryMatchBPM(comment);
+		comment = tryMatchGenreMPM(comment);
+		Q_UNUSED(comment);
+		auto genre = QString::fromStdString(tag->genre().to8Bit(true));
+		genre = tryMatchGenreMPM(genre);
+		Q_UNUSED(genre);
 	}
 
 
@@ -171,22 +178,38 @@ protected:
 		// Pairs of regexp -> genre
 		static const std::vector<std::pair<QRegularExpression, QString>> genreMap =
 		{
-			{ QRegularExpression("(^|[\\W])SW(\\d*)([\\W]|$)", QRegularExpression::CaseInsensitiveOption), "SW" },
-			{ QRegularExpression("(^|[\\W])TG(\\d*)([\\W]|$)", QRegularExpression::CaseInsensitiveOption), "TG" },
-			{ QRegularExpression("(^|[\\W])TA(\\d*)([\\W]|$)", QRegularExpression::CaseInsensitiveOption), "TG" },
-			{ QRegularExpression("(^|[\\W])VW(\\d*)([\\W]|$)", QRegularExpression::CaseInsensitiveOption), "VW" },
-			{ QRegularExpression("(^|[\\W])SF(\\d*)([\\W]|$)", QRegularExpression::CaseInsensitiveOption), "SF" },
-			{ QRegularExpression("(^|[\\W])QS(\\d*)([\\W]|$)", QRegularExpression::CaseInsensitiveOption), "QS" },
-			{ QRegularExpression("(^|[\\W])SB(\\d*)([\\W]|$)", QRegularExpression::CaseInsensitiveOption), "SB" },
-			{ QRegularExpression("(^|[\\W])SA(\\d*)([\\W]|$)", QRegularExpression::CaseInsensitiveOption), "SB" },
-			{ QRegularExpression("(^|[\\W])CH(\\d*)([\\W]|$)", QRegularExpression::CaseInsensitiveOption), "CH" },
-			{ QRegularExpression("(^|[\\W])CC(\\d*)([\\W]|$)", QRegularExpression::CaseInsensitiveOption), "CH" },
-			{ QRegularExpression("(^|[\\W])RU(\\d*)([\\W]|$)", QRegularExpression::CaseInsensitiveOption), "RU" },
-			{ QRegularExpression("(^|[\\W])RB(\\d*)([\\W]|$)", QRegularExpression::CaseInsensitiveOption), "RU" },
-			{ QRegularExpression("(^|[\\W])PD(\\d*)([\\W]|$)", QRegularExpression::CaseInsensitiveOption), "PD" },
-			{ QRegularExpression("(^|[\\W])JI(\\d*)([\\W]|$)", QRegularExpression::CaseInsensitiveOption), "JI" },
-			{ QRegularExpression("(^|[\\W])BL(\\d*)([\\W]|$)", QRegularExpression::CaseInsensitiveOption), "BL" },
-			{ QRegularExpression("(^|[\\W])PO(\\d*)([\\W]|$)", QRegularExpression::CaseInsensitiveOption), "PO" },
+			// Shortcut-based genre + optional MPM:
+			{ QRegularExpression("(^|[\\W])SW(?<mpm>\\d*)(?<end>[\\W]|$)", QRegularExpression::CaseInsensitiveOption), "SW" },
+			{ QRegularExpression("(^|[\\W])TG(?<mpm>\\d*)(?<end>[\\W]|$)", QRegularExpression::CaseInsensitiveOption), "TG" },
+			{ QRegularExpression("(^|[\\W])TA(?<mpm>\\d*)(?<end>[\\W]|$)", QRegularExpression::CaseInsensitiveOption), "TG" },
+			{ QRegularExpression("(^|[\\W])VW(?<mpm>\\d*)(?<end>[\\W]|$)", QRegularExpression::CaseInsensitiveOption), "VW" },
+			{ QRegularExpression("(^|[\\W])SF(?<mpm>\\d*)(?<end>[\\W]|$)", QRegularExpression::CaseInsensitiveOption), "SF" },
+			{ QRegularExpression("(^|[\\W])QS(?<mpm>\\d*)(?<end>[\\W]|$)", QRegularExpression::CaseInsensitiveOption), "QS" },
+			{ QRegularExpression("(^|[\\W])SB(?<mpm>\\d*)(?<end>[\\W]|$)", QRegularExpression::CaseInsensitiveOption), "SB" },
+			{ QRegularExpression("(^|[\\W])SA(?<mpm>\\d*)(?<end>[\\W]|$)", QRegularExpression::CaseInsensitiveOption), "SB" },
+			{ QRegularExpression("(^|[\\W])CH(?<mpm>\\d*)(?<end>[\\W]|$)", QRegularExpression::CaseInsensitiveOption), "CH" },
+			{ QRegularExpression("(^|[\\W])CC(?<mpm>\\d*)(?<end>[\\W]|$)", QRegularExpression::CaseInsensitiveOption), "CH" },
+			{ QRegularExpression("(^|[\\W])RU(?<mpm>\\d*)(?<end>[\\W]|$)", QRegularExpression::CaseInsensitiveOption), "RU" },
+			{ QRegularExpression("(^|[\\W])RB(?<mpm>\\d*)(?<end>[\\W]|$)", QRegularExpression::CaseInsensitiveOption), "RU" },
+			{ QRegularExpression("(^|[\\W])PD(?<mpm>\\d*)(?<end>[\\W]|$)", QRegularExpression::CaseInsensitiveOption), "PD" },
+			{ QRegularExpression("(^|[\\W])JI(?<mpm>\\d*)(?<end>[\\W]|$)", QRegularExpression::CaseInsensitiveOption), "JI" },
+			{ QRegularExpression("(^|[\\W])BL(?<mpm>\\d*)(?<end>[\\W]|$)", QRegularExpression::CaseInsensitiveOption), "BL" },
+			{ QRegularExpression("(^|[\\W])PO(?<mpm>\\d*)(?<end>[\\W]|$)", QRegularExpression::CaseInsensitiveOption), "PO" },
+
+			// Full genre name + optional MPM:
+			{ QRegularExpression("(^|[\\W])slow[-\\s]?waltz\\s?(?<mpm>\\d*)(?<end>[\\W]|$)",    QRegularExpression::CaseInsensitiveOption), "SW" },
+			{ QRegularExpression("(^|[\\W])tango\\s?(?<mpm>\\d*)(?<end>[\\W]|$)",               QRegularExpression::CaseInsensitiveOption), "TG" },
+			{ QRegularExpression("(^|[\\W])valčík\\s?(?<mpm>\\d*)(?<end>[\\W]|$)",              QRegularExpression::CaseInsensitiveOption), "VW" },
+			{ QRegularExpression("(^|[\\W])viennese[-\\s]waltz\\s?(?<mpm>\\d*)(?<end>[\\W]|$)", QRegularExpression::CaseInsensitiveOption), "VW" },
+			{ QRegularExpression("(^|[\\W])slow\\-?fox(trot)?\\s?(?<mpm>\\d*)(?<end>[\\W]|$)",  QRegularExpression::CaseInsensitiveOption), "SF" },
+			{ QRegularExpression("(^|[\\W])quick\\-?step\\s?(?<mpm>\\d*)(?<end>[\\W]|$)",           QRegularExpression::CaseInsensitiveOption), "QS" },
+			{ QRegularExpression("(^|[\\W])samba\\s?(?<mpm>\\d*)(?<end>[\\W]|$)",               QRegularExpression::CaseInsensitiveOption), "SB" },
+			{ QRegularExpression("(^|[\\W])cha\\-?cha(\\-?cha)\\s?(?<mpm>\\d*)(?<end>[\\W]|$)", QRegularExpression::CaseInsensitiveOption), "CH" },
+			{ QRegularExpression("(^|[\\W])rh?umba\\s?(?<mpm>\\d*)(?<end>[\\W]|$)",             QRegularExpression::CaseInsensitiveOption), "RU" },
+			{ QRegularExpression("(^|[\\W])paso[-\\s]?doble\\s?(?<mpm>\\d*)(?<end>[\\W]|$)",    QRegularExpression::CaseInsensitiveOption), "PD" },
+			{ QRegularExpression("(^|[\\W])jive\\s?(?<mpm>\\d*)(?<end>[\\W]|$)",                QRegularExpression::CaseInsensitiveOption), "JI" },
+			{ QRegularExpression("(^|[\\W])blues\\s?(?<mpm>\\d*)(?<end>[\\W]|$)",               QRegularExpression::CaseInsensitiveOption), "BL" },
+			{ QRegularExpression("(^|[\\W])polka\\s?(?<mpm>\\d*)(?<end>[\\W]|$)",               QRegularExpression::CaseInsensitiveOption), "PO" },
 		};
 
 		for (const auto & p: genreMap)
@@ -198,13 +221,14 @@ protected:
 			}
 			if (!m_Song->measuresPerMinute().isValid())
 			{
-				m_Song->setMeasuresPerMinute(match.captured(2).toInt());
+				m_Song->setMeasuresPerMinute(match.captured("mpm").toInt());
 			}
 			if (!m_Song->genre().isValid())
 			{
 				m_Song->setGenre(p.second);
 			}
-			return a_Input.left(match.capturedStart(1) - 1) + " " + a_Input.mid(match.capturedEnd(3));
+			auto prefix = (match.capturedStart(1) > 0) ? a_Input.left(match.capturedStart(1) - 1) : QString();
+			return prefix + " " + a_Input.mid(match.capturedEnd("end"));
 		}
 		return res;
 	}

--- a/MetadataScanner.cpp
+++ b/MetadataScanner.cpp
@@ -143,8 +143,6 @@ protected:
 	Returns the string excluding the genre / MPM substring. */
 	QString tryMatchGenreMPM(const QString & a_Input)
 	{
-		auto res = a_Input;
-
 		// Pairs of regexp -> genre
 		static const std::vector<std::pair<QRegularExpression, QString>> genreMap =
 		{
@@ -167,19 +165,19 @@ protected:
 			{ QRegularExpression("(^|[\\W])PO(?<mpm>\\d*)(?<end>[\\W]|$)", QRegularExpression::CaseInsensitiveOption), "PO" },
 
 			// Full genre name + optional MPM:
-			{ QRegularExpression("(^|[\\W])slow[-\\s]?waltz\\s?(?<mpm>\\d*)(?<end>[\\W]|$)",    QRegularExpression::CaseInsensitiveOption), "SW" },
-			{ QRegularExpression("(^|[\\W])tango\\s?(?<mpm>\\d*)(?<end>[\\W]|$)",               QRegularExpression::CaseInsensitiveOption), "TG" },
-			{ QRegularExpression("(^|[\\W])valčík\\s?(?<mpm>\\d*)(?<end>[\\W]|$)",              QRegularExpression::CaseInsensitiveOption), "VW" },
-			{ QRegularExpression("(^|[\\W])viennese[-\\s]waltz\\s?(?<mpm>\\d*)(?<end>[\\W]|$)", QRegularExpression::CaseInsensitiveOption), "VW" },
-			{ QRegularExpression("(^|[\\W])slow\\-?fox(trot)?\\s?(?<mpm>\\d*)(?<end>[\\W]|$)",  QRegularExpression::CaseInsensitiveOption), "SF" },
-			{ QRegularExpression("(^|[\\W])quick\\-?step\\s?(?<mpm>\\d*)(?<end>[\\W]|$)",           QRegularExpression::CaseInsensitiveOption), "QS" },
-			{ QRegularExpression("(^|[\\W])samba\\s?(?<mpm>\\d*)(?<end>[\\W]|$)",               QRegularExpression::CaseInsensitiveOption), "SB" },
-			{ QRegularExpression("(^|[\\W])cha\\-?cha(\\-?cha)\\s?(?<mpm>\\d*)(?<end>[\\W]|$)", QRegularExpression::CaseInsensitiveOption), "CH" },
-			{ QRegularExpression("(^|[\\W])rh?umba\\s?(?<mpm>\\d*)(?<end>[\\W]|$)",             QRegularExpression::CaseInsensitiveOption), "RU" },
-			{ QRegularExpression("(^|[\\W])paso[-\\s]?doble\\s?(?<mpm>\\d*)(?<end>[\\W]|$)",    QRegularExpression::CaseInsensitiveOption), "PD" },
-			{ QRegularExpression("(^|[\\W])jive\\s?(?<mpm>\\d*)(?<end>[\\W]|$)",                QRegularExpression::CaseInsensitiveOption), "JI" },
-			{ QRegularExpression("(^|[\\W])blues\\s?(?<mpm>\\d*)(?<end>[\\W]|$)",               QRegularExpression::CaseInsensitiveOption), "BL" },
-			{ QRegularExpression("(^|[\\W])polka\\s?(?<mpm>\\d*)(?<end>[\\W]|$)",               QRegularExpression::CaseInsensitiveOption), "PO" },
+			{ QRegularExpression("(^|[\\W])vien(nese|n?a)[-\\s]waltz\\s?(?<mpm>\\d*)(?<end>[\\W]|$)", QRegularExpression::CaseInsensitiveOption), "VW" },  // Must be earlier than SW, because "vienna waltz" matches SW too
+			{ QRegularExpression("(^|[\\W])(slow[-\\s]?)?waltz\\s?(?<mpm>\\d*)(?<end>[\\W]|$)",       QRegularExpression::CaseInsensitiveOption), "SW" },
+			{ QRegularExpression("(^|[\\W])tango\\s?(?<mpm>\\d*)(?<end>[\\W]|$)",                     QRegularExpression::CaseInsensitiveOption), "TG" },
+			{ QRegularExpression("(^|[\\W])valčík\\s?(?<mpm>\\d*)(?<end>[\\W]|$)",                    QRegularExpression::CaseInsensitiveOption), "VW" },
+			{ QRegularExpression("(^|[\\W])slow\\-?fox(trot)?\\s?(?<mpm>\\d*)(?<end>[\\W]|$)",        QRegularExpression::CaseInsensitiveOption), "SF" },
+			{ QRegularExpression("(^|[\\W])quick\\-?step\\s?(?<mpm>\\d*)(?<end>[\\W]|$)",             QRegularExpression::CaseInsensitiveOption), "QS" },
+			{ QRegularExpression("(^|[\\W])samba\\s?(?<mpm>\\d*)(?<end>[\\W]|$)",                     QRegularExpression::CaseInsensitiveOption), "SB" },
+			{ QRegularExpression("(^|[\\W])cha\\-?cha(\\-?cha)\\s?(?<mpm>\\d*)(?<end>[\\W]|$)",       QRegularExpression::CaseInsensitiveOption), "CH" },
+			{ QRegularExpression("(^|[\\W])rh?umba\\s?(?<mpm>\\d*)(?<end>[\\W]|$)",                   QRegularExpression::CaseInsensitiveOption), "RU" },
+			{ QRegularExpression("(^|[\\W])paso[-\\s]?doble\\s?(?<mpm>\\d*)(?<end>[\\W]|$)",          QRegularExpression::CaseInsensitiveOption), "PD" },
+			{ QRegularExpression("(^|[\\W])jive\\s?(?<mpm>\\d*)(?<end>[\\W]|$)",                      QRegularExpression::CaseInsensitiveOption), "JI" },
+			{ QRegularExpression("(^|[\\W])blues\\s?(?<mpm>\\d*)(?<end>[\\W]|$)",                     QRegularExpression::CaseInsensitiveOption), "BL" },
+			{ QRegularExpression("(^|[\\W])polka\\s?(?<mpm>\\d*)(?<end>[\\W]|$)",                     QRegularExpression::CaseInsensitiveOption), "PO" },
 		};
 
 		for (const auto & p: genreMap)
@@ -191,7 +189,12 @@ protected:
 			}
 			if (!m_Song->measuresPerMinute().isValid())
 			{
-				m_Song->setMeasuresPerMinute(match.captured("mpm").toInt());
+				bool isOK = false;
+				auto mpm = match.captured("mpm").toInt(&isOK);
+				if (isOK && (mpm > 0))
+				{
+					m_Song->setMeasuresPerMinute(mpm);
+				}
 			}
 			if (!m_Song->genre().isValid())
 			{
@@ -200,7 +203,7 @@ protected:
 			auto prefix = (match.capturedStart(1) > 0) ? a_Input.left(match.capturedStart(1) - 1) : QString();
 			return prefix + " " + a_Input.mid(match.capturedEnd("end"));
 		}
-		return res;
+		return a_Input;
 	}
 
 

--- a/SongModel.h
+++ b/SongModel.h
@@ -53,6 +53,10 @@ public:
 	/** Returns the song represented by the specified row. */
 	SongPtr songFromRow(int a_Row) const;
 
+	/** Returns the QModelIndex representing the specified song, pointing to the specified column.
+	Asserts and returns an invalid QModelIndex if song not found. */
+	QModelIndex indexFromSong(const Song * a_Song, int a_Column = 0);
+
 protected:
 
 	/** The DB on which the model is based. */
@@ -67,10 +71,14 @@ protected:
 	virtual Qt::ItemFlags flags(const QModelIndex & a_Index) const override;
 	virtual bool setData(const QModelIndex & a_Index, const QVariant & a_Value, int a_Role) override;
 
+
 protected slots:
 
-	/** Called by m_DB when a new song is added to it. */
+	/** Emitted by m_DB when a new song is added to it. */
 	void addSongFile(Song * a_NewSong);
+
+	/** Emitted by m_DB.metadataScanner after a song metadata is updated by a scan. */
+	void songMetadataScanned(Song * a_Song);
 
 
 signals:


### PR DESCRIPTION
WIP, implements #19 
 - [x] If the filename contains "XY BPM", set MPM to XY
 - [x] If the filename contains SW in capitals separate from other text, and SW is a valid genre, set genre to SW
 - [x] If the ID3 tag contains comment "XY BPM", set MPM to XY
 - [x] If the ID3 tag contains comment "SW" and SW is a valid genre, set genre to SW
 - [x] If the ID3 tag contains genre "slow-waltz", set genre to SW
 - [x] If the ID3 tag contains comment "slow-waltz", set genre to SW
 - [x] If (any) parent folder name contains "slow waltz", set genre to SW
 - [x] If the filename contains "SW30", set genre to SW and MPM to 30
 - [ ] If the filename contains "Sw 30", set genre to SW and MPM to 30