### PR TITLE
Fix CI build

### DIFF
--- a/appveyor-build.cmd
+++ b/appveyor-build.cmd
@@ -2,6 +2,7 @@
 
 rem Download the ffmpeg's LibAV for Windows, version 3.4.1:
 if not exist c:\projects\lib\include\avformat\avformat.h (
+	echo -------------------------
 	echo Downloading precompiled LibAV libraries from ffmpeg...
 	mkdir c:\projects\lib
 	curl -o c:\projects\lib\libav.zip https://ffmpeg.zeranoe.com/builds/win64/dev/ffmpeg-3.4.1-win64-dev.zip
@@ -20,6 +21,7 @@ if not exist c:\projects\lib\include\avformat\avformat.h (
 
 rem Download the precompiled TagLib:
 if not exist c:\projects\lib\include\taglib\tag.h (
+	echo -------------------------
 	echo Downloading precompiled TagLib libraries...
 	curl -o c:\projects\lib\taglib.7z http://xoft.cz/taglib-msvc2015-x64.7z
 	if errorlevel 1 (
@@ -32,11 +34,17 @@ if not exist c:\projects\lib\include\taglib\tag.h (
 		exit /b 1
 	)
 )
+echo -------------------------
 echo Libraries checked, compiling now...
 
 call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat" amd64
 set LIB=%LIB%;c:\projects\lib\lib
 set INCLUDE=%INCLUDE%;c:\projects\lib\include
+
+echo -------------------------
+echo Running QMake...
 qmake SkauTan.pro
-set
+
+echo -------------------------
+echo Running nmake...
 nmake

--- a/appveyor-build.cmd
+++ b/appveyor-build.cmd
@@ -39,4 +39,5 @@ set INCLUDE=%INCLUDE%;c:\projects\lib\include
 
 call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat" amd64
 qmake SkauTan.pro
+set
 nmake

--- a/appveyor-build.cmd
+++ b/appveyor-build.cmd
@@ -34,10 +34,9 @@ if not exist c:\projects\lib\include\taglib\tag.h (
 )
 echo Libraries checked, compiling now...
 
+call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat" amd64
 set LIB=%LIB%;c:\projects\lib\lib
 set INCLUDE=%INCLUDE%;c:\projects\lib\include
-
-call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat" amd64
 qmake SkauTan.pro
 set
 nmake


### PR DESCRIPTION
After an MSVC update, Appveyor builds fail because they cannot find the libs.
WIP to fix the problem.