### PR TITLE
Audio output in a background thread

### DIFF
--- a/AudioDataSource.h
+++ b/AudioDataSource.h
@@ -167,9 +167,20 @@ public:
 	virtual qint64 readData(char * a_Data, qint64 a_MaxLen) override
 	{
 		assert(a_MaxLen >= 0);
+
+		// Skip zero-length reads:
+		if (a_MaxLen <= 0)
+		{
+			return 0;
+		}
+
 		auto res = static_cast<qint64>(AudioDataSourceChain::read(a_Data, static_cast<size_t>(a_MaxLen)));
 		#ifdef _DEBUG
-			qDebug() << __FUNCTION__ << " @ " << TimeSinceStart::msecElapsed() << ": Requested " << a_MaxLen << " bytes, got " << res << " bytes.";
+			static auto lastMsec = TimeSinceStart::msecElapsed();
+			auto msecNow = TimeSinceStart::msecElapsed();
+			qDebug() << __FUNCTION__ << ": Requested " << a_MaxLen << " bytes, got " << res << " bytes; since last: "
+				<< msecNow - lastMsec << " msec";
+			lastMsec = msecNow;
 		#endif  // _DEBUG
 		return res;
 	}

--- a/Player.h
+++ b/Player.h
@@ -65,6 +65,11 @@ protected:
 		psFadeOutToStop,   ///< The player is fading out a track and will stop playing once done.
 	};
 
+
+	// fwd:
+	class OutputThread;
+
+
 	/** The playlist on which this instance is operating. */
 	std::shared_ptr<Playlist> m_Playlist;
 
@@ -75,17 +80,14 @@ protected:
 	0 = fadeout just started. */
 	int m_FadeoutProgress;
 
-	/** The actual audio output. */
-	std::unique_ptr<QAudioOutput> m_Output;
+	/** The thread that does the audio output processing. */
+	std::unique_ptr<OutputThread> m_OutputThread;
 
 	/** The source of the audio data, adapted into QIODevice interface. */
 	std::unique_ptr<AudioDataSourceIO> m_AudioDataSource;
 
 	/** The format used by the audio output. */
 	QAudioFormat m_Format;
-
-	/** The thread in which the audio output is run. */
-	QThread m_Thread;
 
 	/** The tempo to be used for playback. */
 	qreal m_Tempo;

--- a/SongDecoder.cpp
+++ b/SongDecoder.cpp
@@ -4,11 +4,6 @@
 
 
 
-std::atomic<bool> g_IsAVInitialized(false);
-
-
-
-
 
 ////////////////////////////////////////////////////////////////////////////////
 // SongDecoder:
@@ -70,4 +65,5 @@ void SongDecoder::decodeInternal()
 	}
 	m_FmtCtx->routeAudioTo(this);
 	m_FmtCtx->decode();
+	qDebug() << "Decoding has finished file " << m_Song->fileName();
 }


### PR DESCRIPTION
This is the proper way to move the audio output to a separate thread.

Fixes #54.