### PR TITLE
Show background tasks

### DIFF
--- a/AVPP.cpp
+++ b/AVPP.cpp
@@ -126,7 +126,7 @@ int FileIO::read(void * a_This, uint8_t * a_Dst, int a_Size)
 
 int64_t FileIO::seek(void * a_This, int64_t a_Offset, int a_Whence)
 {
-	qDebug() << ": Seek to offset " << a_Offset << " from " << a_Whence;
+	// qDebug() << ": Seek to offset " << a_Offset << " from " << a_Whence;
 	auto This = reinterpret_cast<FileIO *>(a_This);
 	switch (a_Whence)
 	{
@@ -501,7 +501,7 @@ FormatPtr Format::createContext(const QString & a_FileName)
 		qWarning() << ": Cannot find stream info: " << ret;
 	}
 
-	qDebug() << ": Format context initialized.";
+	// qDebug() << ": Format context initialized.";
 	return res;
 }
 

--- a/DlgBackgroundTaskList.cpp
+++ b/DlgBackgroundTaskList.cpp
@@ -1,0 +1,104 @@
+#include "DlgBackgroundTaskList.h"
+#include "ui_DlgBackgroundTaskList.h"
+#include <assert.h>
+#include <QDebug>
+#include "Stopwatch.h"
+
+
+
+
+
+DlgBackgroundTaskList::DlgBackgroundTaskList(QWidget * a_Parent) :
+	Super(a_Parent),
+	m_UI(new Ui::DlgBackgroundTaskList)
+{
+	m_UI->setupUi(this);
+	auto & backgroundTasks = BackgroundTasks::get();
+
+	// Connect the signals:
+	connect(&backgroundTasks, &BackgroundTasks::taskAdded,    this, &DlgBackgroundTaskList::addTask);
+	connect(&backgroundTasks, &BackgroundTasks::taskFinished, this, &DlgBackgroundTaskList::delTask);
+	connect(&backgroundTasks, &BackgroundTasks::taskAborted,  this, &DlgBackgroundTaskList::delTask);
+	connect(m_UI->btnClose,   &QPushButton::clicked,          this, &QDialog::close);
+	connect(&m_UpdateTimer,   &QTimer::timeout,               this, &DlgBackgroundTaskList::periodicUpdateUi);
+
+	// Insert the current tasks:
+	for (const auto & task: backgroundTasks.tasks())
+	{
+		addTask(task);
+	}
+
+	// Start the UI updater, update UI every half second:
+	m_UpdateTimer.start(500);
+}
+
+
+
+
+
+DlgBackgroundTaskList::~DlgBackgroundTaskList()
+{
+	// Nothing explicit needed, but must be in the CPP file due to m_UI.
+}
+
+
+
+
+
+void DlgBackgroundTaskList::updateCountLabel()
+{
+	m_UI->lblTasks->setText(tr("Background tasks: %1").arg(m_UI->lwTasks->count()));
+}
+
+
+
+
+
+void DlgBackgroundTaskList::addTask(BackgroundTasks::TaskPtr a_Task)
+{
+	// Postpone action into the UI update
+	assert(a_Task != nullptr);
+	m_TasksToAdd.push_back(std::move(a_Task));
+}
+
+
+
+
+
+void DlgBackgroundTaskList::delTask(BackgroundTasks::TaskPtr a_Task)
+{
+	// Postpone action into the UI update
+	assert(a_Task != nullptr);
+	m_TasksToRemove.push_back(std::move(a_Task));
+}
+
+
+
+
+
+void DlgBackgroundTaskList::periodicUpdateUi()
+{
+	// Add new tasks:
+	for (const auto & task: m_TasksToAdd)
+	{
+		auto item = new QListWidgetItem(task->name());
+		m_TaskItemMap[task] = item;
+		m_UI->lwTasks->addItem(item);
+	}
+	m_TasksToAdd.clear();
+
+	// Remove finished tasks:
+	for (const auto & task: m_TasksToRemove)
+	{
+		auto itr = m_TaskItemMap.find(task);
+		if (itr != m_TaskItemMap.end())
+		{
+			auto item = itr->second;
+			m_TaskItemMap.erase(itr);
+			delete item;  // Removes the item from the widget
+		}
+	}
+	m_TasksToRemove.clear();
+
+	updateCountLabel();
+}

--- a/DlgBackgroundTaskList.h
+++ b/DlgBackgroundTaskList.h
@@ -1,0 +1,82 @@
+#ifndef DLGBACKGROUNDTASKLIST_H
+#define DLGBACKGROUNDTASKLIST_H
+
+
+
+
+
+#include <memory>
+#include <QDialog>
+#include <QTimer>
+#include "BackgroundTasks.h"
+
+
+
+
+
+// fwd:
+class QListWidgetItem;
+namespace Ui
+{
+	class DlgBackgroundTaskList;
+}
+
+
+
+
+
+class DlgBackgroundTaskList:
+	public QDialog
+{
+	using Super = QDialog;
+
+	Q_OBJECT
+
+
+public:
+
+	explicit DlgBackgroundTaskList(QWidget * a_Parent = nullptr);
+	virtual ~DlgBackgroundTaskList() override;
+
+
+private:
+
+	/** The Qt-managed UI. */
+	std::unique_ptr<Ui::DlgBackgroundTaskList> m_UI;
+
+	/** Maps tasks to items for faster lookup. */
+	std::map<BackgroundTasks::TaskPtr, QListWidgetItem *> m_TaskItemMap;
+
+	/** Tasks that should be added to the UI on the next periodic update. */
+	std::vector<BackgroundTasks::TaskPtr> m_TasksToAdd;
+
+	/** Tasks that should be removed from the UI on the next periodic update. */
+	std::vector<BackgroundTasks::TaskPtr> m_TasksToRemove;
+
+	/** The timer used for periodic UI updates. */
+	QTimer m_UpdateTimer;
+
+
+	/** Updates m_UI->lblTasks with the current count of the tasks. */
+	void updateCountLabel();
+
+
+private slots:
+
+	/** Emitted by BackgroundTasks after a task is added to the queue.
+	Queues adding a new task to the UI. */
+	void addTask(BackgroundTasks::TaskPtr a_Task);
+
+	/** Emitted by BackgroundTasks after a task is finished or aborted.
+	Queues removing the task from the UI. */
+	void delTask(BackgroundTasks::TaskPtr a_Task);
+
+	/** Called periodically to update the UI (task list and count). */
+	void periodicUpdateUi();
+};
+
+
+
+
+
+#endif // DLGBACKGROUNDTASKLIST_H

--- a/DlgBackgroundTaskList.ui
+++ b/DlgBackgroundTaskList.ui
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>DlgBackgroundTaskList</class>
+ <widget class="QDialog" name="DlgBackgroundTaskList">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>777</width>
+    <height>598</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>SkauTan: Background tasks</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
+    <widget class="QListWidget" name="lwTasks"/>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="lblTasks">
+       <property name="text">
+        <string notr="true">Background tasks: 5</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnClose">
+       <property name="text">
+        <string>&amp;Close</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/HashCalculator.cpp
+++ b/HashCalculator.cpp
@@ -22,7 +22,7 @@ HashCalculator::HashCalculator()
 
 void HashCalculator::queueHashSong(SongPtr a_Song)
 {
-	BackgroundTasks::enqueue([this, a_Song]()
+	BackgroundTasks::enqueue(tr("Calculate hash: %1").arg(a_Song->fileName()), [this, a_Song]()
 		{
 			auto context = AVPP::Format::createContext(a_Song->fileName());
 			if (context == nullptr)

--- a/MetadataScanner.cpp
+++ b/MetadataScanner.cpp
@@ -255,7 +255,7 @@ MetadataScanner::MetadataScanner()
 
 void MetadataScanner::queueScanSong(SongPtr a_Song)
 {
-	BackgroundTasks::enqueue([this, a_Song]()
+	BackgroundTasks::enqueue(tr("Scan metadata: %1").arg(a_Song->fileName()), [this, a_Song]()
 		{
 			SongProcessor proc(a_Song);
 			proc.process();

--- a/PlayerWindow.cpp
+++ b/PlayerWindow.cpp
@@ -3,6 +3,7 @@
 #include <QDebug>
 #include <QShortcut>
 #include <QTimer>
+#include <QMenu>
 #include "ui_PlayerWindow.h"
 #include "Database.h"
 #include "DlgSongs.h"
@@ -12,6 +13,7 @@
 #include "Player.h"
 #include "DlgPickTemplate.h"
 #include "DlgQuickPlayer.h"
+#include "DlgBackgroundTaskList.h"
 
 
 
@@ -58,6 +60,8 @@ PlayerWindow::PlayerWindow(Database & a_DB, MetadataScanner & a_Scanner, Player 
 	connect(m_UI->hsPosition,         &QSlider::valueChanged,     this, &PlayerWindow::setTimePos);
 	connect(m_UI->vsTempo,            &QSlider::valueChanged,     this, &PlayerWindow::tempoValueChanged);
 	connect(m_UI->btnTempoReset,      &QToolButton::clicked,      this, &PlayerWindow::resetTempo);
+	connect(m_UI->btnTools,           &QPushButton::clicked,      this, &PlayerWindow::showToolsMenu);
+	connect(m_UI->actBackgroundTasks, &QAction::triggered,        this, &PlayerWindow::showBackgroundTasks);
 
 	// Update the UI every 200 msec:
 	m_UpdateUITimer->start(200);
@@ -332,4 +336,26 @@ void PlayerWindow::tempoValueChanged(int a_NewValue)
 void PlayerWindow::resetTempo()
 {
 	m_UI->vsTempo->setValue(0);
+}
+
+
+
+
+
+void PlayerWindow::showToolsMenu()
+{
+	QMenu menu;
+	menu.addAction(m_UI->actBackgroundTasks);
+	menu.addSeparator();
+	menu.exec(m_UI->btnTools->mapToGlobal(QPoint(0, 0)));
+}
+
+
+
+
+
+void PlayerWindow::showBackgroundTasks()
+{
+	DlgBackgroundTaskList dlg(this);
+	dlg.exec();
 }

--- a/PlayerWindow.h
+++ b/PlayerWindow.h
@@ -137,6 +137,12 @@ private slots:
 
 	/** The user clicker the Reset tempo button, resets tempo to 100 %. */
 	void resetTempo();
+
+	/** Shows the Tools popup menu. */
+	void showToolsMenu();
+
+	/** Shows the BackgroundTasks dialog. */
+	void showBackgroundTasks();
 };
 
 

--- a/PlayerWindow.ui
+++ b/PlayerWindow.ui
@@ -53,6 +53,13 @@
        </widget>
       </item>
       <item>
+       <widget class="QPushButton" name="btnTools">
+        <property name="text">
+         <string>T&amp;ools</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <spacer name="verticalSpacer">
         <property name="orientation">
          <enum>Qt::Vertical</enum>
@@ -279,6 +286,11 @@
     </item>
    </layout>
   </widget>
+  <action name="actBackgroundTasks">
+   <property name="text">
+    <string>Background tasks</string>
+   </property>
+  </action>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
  <resources/>

--- a/SkauTan.pro
+++ b/SkauTan.pro
@@ -86,6 +86,7 @@ SOURCES += \
 	Stopwatch.cpp \
 	DlgChooseImportTemplates.cpp \
 	BackgroundTasks.cpp \
+	DlgBackgroundTaskList.cpp \
 
 HEADERS += \
 	PlayerWindow.h \
@@ -117,6 +118,7 @@ HEADERS += \
 	AudioEffects.h \
 	DlgChooseImportTemplates.h \
 	BackgroundTasks.h \
+	DlgBackgroundTaskList.h \
 
 FORMS += \
 	PlayerWindow.ui \
@@ -129,6 +131,7 @@ FORMS += \
 	DlgPickTemplate.ui \
 	DlgQuickPlayer.ui \
 	DlgChooseImportTemplates.ui \
+	DlgBackgroundTaskList.ui \
 
 RESOURCES += \
 	res/SkauTan.qrc


### PR DESCRIPTION
Added a dialog to show all background tasks.
Since there may be many tasks, the dialog updates only twice a second, rather than on each task addition / completion.

Also, this is the first implementation of sending messages between threads using Qt's `QMetaObject::invokeMethod`.