### PR TITLE
Split song DB

### DIFF
--- a/DlgQuickPlayer.cpp
+++ b/DlgQuickPlayer.cpp
@@ -5,6 +5,7 @@
 #include <QDebug>
 #include "Database.h"
 #include "Player.h"
+#include "Playlist.h"
 
 
 

--- a/DlgSongs.cpp
+++ b/DlgSongs.cpp
@@ -7,6 +7,7 @@
 #include "Database.h"
 #include "MetadataScanner.h"
 #include "AVPP.h"
+#include "Stopwatch.h"
 
 
 
@@ -53,7 +54,11 @@ DlgSongs::DlgSongs(
 	connect(m_UI->btnRescanMetadata, &QPushButton::clicked,  this, &DlgSongs::rescanMetadata);
 	connect(&m_SongModel,            &SongModel::songEdited, this, &DlgSongs::modelSongEdited);
 
-	m_UI->tblSongs->resizeColumnsToContents();
+	// Resize the table columns to fit the song data:
+	{
+		STOPWATCH("Resize song columns");
+		m_UI->tblSongs->resizeColumnsToContents();
+	}
 
 	// Make the dialog have Maximize button on Windows:
 	setWindowFlags(Qt::Window);

--- a/PlayerWindow.cpp
+++ b/PlayerWindow.cpp
@@ -114,6 +114,7 @@ void PlayerWindow::showSongs(bool a_IsChecked)
 
 	DlgSongs dlg(m_DB, m_MetadataScanner, nullptr, true, this);
 	connect(&dlg, &DlgSongs::addSongToPlaylist, this, &PlayerWindow::addSong);
+	dlg.showMaximized();
 	dlg.exec();
 }
 

--- a/Song.cpp
+++ b/Song.cpp
@@ -8,12 +8,10 @@
 
 Song::Song(
 	const QString & a_FileName,
-	qulonglong a_FileSize,
-	qlonglong a_DbRowId
+	qulonglong a_FileSize
 ):
 	m_FileName(a_FileName),
-	m_FileSize(a_FileSize),
-	m_DbRowId(a_DbRowId)
+	m_FileSize(a_FileSize)
 {
 }
 
@@ -24,7 +22,6 @@ Song::Song(
 Song::Song(
 	QString && a_FileName,
 	qulonglong a_FileSize,
-	qlonglong a_DbRowId,
 	QVariant && a_Hash,
 	QVariant && a_Length,
 	Tag && a_TagManual,
@@ -36,7 +33,6 @@ Song::Song(
 ):
 	m_FileName(std::move(a_FileName)),
 	m_FileSize(a_FileSize),
-	m_DbRowId(a_DbRowId),
 	m_Hash(std::move(a_Hash)),
 	m_Length(std::move(a_Length)),
 	m_TagManual(std::move(a_TagManual)),
@@ -46,7 +42,6 @@ Song::Song(
 	m_Rating(std::move(a_Rating)),
 	m_LastMetadataUpdated(std::move(a_LastMetadataUpdated))
 {
-	// Nothing needed
 }
 
 
@@ -158,6 +153,21 @@ bool Song::needsMetadataRescan() const
 		return (m_LastMetadataUpdated.toDateTime() < QDateTime::currentDateTimeUtc().addDays(-14));
 	}
 	return false;
+}
+
+
+
+
+
+void Song::copyMetadataFrom(const Song & a_Src)
+{
+	m_Length              = a_Src.m_Length;
+	m_TagManual           = a_Src.m_TagManual;
+	m_TagFileName         = a_Src.m_TagFileName;
+	m_TagId3              = a_Src.m_TagId3;
+	m_LastPlayed          = a_Src.m_LastPlayed;
+	m_Rating              = a_Src.m_Rating;
+	m_LastMetadataUpdated = a_Src.m_LastMetadataUpdated;
 }
 
 

--- a/Song.h
+++ b/Song.h
@@ -40,15 +40,13 @@ public:
 	/** Creates a new instance that has only the file name and size set, all the other metadata are empty.
 	Used when adding new files. */
 	explicit Song(const QString & a_FileName,
-		qulonglong a_FileSize,
-		qlonglong a_DbRowId
+		qulonglong a_FileSize
 	);
 
 	/** Creates a new instance with all fields set.
 	Used when loading songs from the DB. */
 	explicit Song(QString && a_FileName,
 		qulonglong a_FileSize,
-		qlonglong a_DbRowId,
 		QVariant && a_Hash,
 		QVariant && a_Length,
 		Tag && a_TagManual,
@@ -61,7 +59,6 @@ public:
 
 	const QString & fileName() const { return m_FileName; }
 	qulonglong fileSize() const { return m_FileSize; }
-	qlonglong dbRowId() const { return m_DbRowId; }
 	const QVariant & hash() const { return m_Hash; }
 	const QVariant & length() const { return m_Length; }
 	const Tag & tagManual() const { return m_TagManual; }
@@ -110,11 +107,15 @@ public:
 	SongDatabase uses this to decide whether to queue the song for re-scan upon loading the DB. */
 	bool needsMetadataRescan() const;
 
+	/** Copies all metadata from the specified source song.
+	This is used when a hash duplicate is detected. */
+	void copyMetadataFrom(const Song & a_Src);
+
+
 protected:
 
 	QString m_FileName;
 	qulonglong m_FileSize;
-	qlonglong m_DbRowId;
 	QVariant m_Hash;
 	QVariant m_Length;
 	Tag m_TagManual;


### PR DESCRIPTION
Songs are now stored in two tables: SongHashes (filename -> hash) and SongMetadata (hash -> metadata).

This will allow duplicate detection, and is the base for further features (such as metadata sync)

Fixes #71.