### PR TITLE
MetadataScanner: Ignore matches when a differrent genre already assigned

### DIFF
--- a/MetadataScanner.cpp
+++ b/MetadataScanner.cpp
@@ -152,10 +152,11 @@ protected:
 			{ QRegularExpression("(^|[\\W])PO(?<mpm>\\d*)(?<end>[\\W]|$)", QRegularExpression::CaseInsensitiveOption), "PO" },
 
 			// Full genre name + optional MPM:
+			{ QRegularExpression("(^|[\\W])valčík\\s?(?<mpm>\\d*)(?<end>[\\W]|$)",                    QRegularExpression::CaseInsensitiveOption), "VW" },  // Must be earlier than SW, because many VW songs contain "waltz" that would match SW too
+			{ QRegularExpression("(^|[\\W])valcik\\s?(?<mpm>\\d*)(?<end>[\\W]|$)",                    QRegularExpression::CaseInsensitiveOption), "VW" },  // Must be earlier than SW, because many VW songs contain "waltz" that would match SW too
 			{ QRegularExpression("(^|[\\W])vien(nese|n?a)[-\\s]waltz\\s?(?<mpm>\\d*)(?<end>[\\W]|$)", QRegularExpression::CaseInsensitiveOption), "VW" },  // Must be earlier than SW, because "vienna waltz" matches SW too
 			{ QRegularExpression("(^|[\\W])(slow[-\\s]?)?waltz\\s?(?<mpm>\\d*)(?<end>[\\W]|$)",       QRegularExpression::CaseInsensitiveOption), "SW" },
 			{ QRegularExpression("(^|[\\W])tango\\s?(?<mpm>\\d*)(?<end>[\\W]|$)",                     QRegularExpression::CaseInsensitiveOption), "TG" },
-			{ QRegularExpression("(^|[\\W])valčík\\s?(?<mpm>\\d*)(?<end>[\\W]|$)",                    QRegularExpression::CaseInsensitiveOption), "VW" },
 			{ QRegularExpression("(^|[\\W])slow\\-?fox(trot)?\\s?(?<mpm>\\d*)(?<end>[\\W]|$)",        QRegularExpression::CaseInsensitiveOption), "SF" },
 			{ QRegularExpression("(^|[\\W])quick\\-?step\\s?(?<mpm>\\d*)(?<end>[\\W]|$)",             QRegularExpression::CaseInsensitiveOption), "QS" },
 			{ QRegularExpression("(^|[\\W])samba\\s?(?<mpm>\\d*)(?<end>[\\W]|$)",                     QRegularExpression::CaseInsensitiveOption), "SB" },
@@ -172,6 +173,12 @@ protected:
 			auto match = p.first.match(a_Input);
 			if (!match.hasMatch())
 			{
+				continue;
+			}
+			if (a_OutputTag.m_Genre.isValid() && (a_OutputTag.m_Genre.toString() != p.second))
+			{
+				qDebug() << "String \"" << a_Input << "\" has matched genre " << p.second
+					<< ", but already has genre " << a_OutputTag.m_Genre.toString() << ", ignoring the match";
 				continue;
 			}
 			bool isOK = false;


### PR DESCRIPTION
Fixes #81 by providing a workaround - by moving the song to an appropriate folder (and setting genre properly in ID3 tag), the wrong match is ignored because a different (correct) genre has already been detected.

E.g.: song D:/MP3/Tanecni - tridene/Valcik/[59 BPM] Waltz For The Moon.mp3:
  1. matches VW by folder name "Valcik"
  2. matches SW by name substring "Waltz", but VW already assigned -> ignored