### PR TITLE
DB: Split file- and song-related data

### DIFF
--- a/Database.h
+++ b/Database.h
@@ -85,6 +85,9 @@ public:
 
 protected:
 
+	friend class DatabaseUpgrade;
+
+
 	/** The DB connection .*/
 	QSqlDatabase m_Database;
 
@@ -138,6 +141,10 @@ protected:
 
 	/** Updates the song metadata in the SongMetadata DB table. */
 	void saveSongMetadata(SongPtr a_Song);
+
+	/** Returns the internal Qt DB object.
+	Only used in the DatabaseUpgrade class. */
+	QSqlDatabase & database() { return m_Database; }
 
 
 signals:

--- a/DatabaseUpgrade.cpp
+++ b/DatabaseUpgrade.cpp
@@ -1,0 +1,229 @@
+#include "DatabaseUpgrade.h"
+#include <vector>
+#include <QSqlError>
+#include <QSqlRecord>
+#include <QDebug>
+#include "Database.h"
+
+
+
+
+
+class VersionScript
+{
+public:
+	VersionScript(std::vector<std::string> && a_Commands):
+		m_Commands(std::move(a_Commands))
+	{}
+
+	std::vector<std::string> m_Commands;
+
+
+	/** Applies this upgrade script to the specified DB, and updates its version to a_Version. */
+	void apply(QSqlDatabase & a_DB, size_t a_Version) const
+	{
+		qDebug() << "Executing DB upgrade script to version " << a_Version;
+
+		// Begin transaction:
+		auto query = a_DB.exec("begin");
+		if (query.lastError().type() != QSqlError::NoError)
+		{
+			qWarning() << "SQL query failed: " << query.lastError();
+			throw DatabaseUpgrade::SqlError(query.lastError(), "begin");
+		}
+
+		// Execute the individual commands:
+		for (const auto & cmd: m_Commands)
+		{
+			auto query = a_DB.exec(QString::fromStdString(cmd));
+			if (query.lastError().type() != QSqlError::NoError)
+			{
+				qWarning() << "SQL upgrade command failed: " << query.lastError();
+				qDebug() << "  ^-- command: " << cmd.c_str();
+				throw DatabaseUpgrade::SqlError(query.lastError(), cmd);
+			}
+		}
+
+		// Set the new version:
+		{
+			auto query = a_DB.exec(QString("UPDATE Version SET Version = %1").arg(a_Version));
+			if (query.lastError().type() != QSqlError::NoError)
+			{
+				qWarning() << "SQL transaction commit failed: " << query.lastError();
+				throw DatabaseUpgrade::SqlError(query.lastError(), query.lastQuery().toStdString());
+			}
+		}
+
+		// Commit the transaction:
+		{
+			auto query = a_DB.exec("commit");
+			if (query.lastError().type() != QSqlError::NoError)
+			{
+				qWarning() << "SQL transaction commit failed: " << query.lastError();
+				throw DatabaseUpgrade::SqlError(query.lastError(), "commit");
+			}
+		}
+	}
+};
+
+
+
+
+
+
+static const std::vector<VersionScript> g_VersionScripts =
+{
+	// Version 0 (no versioning info / empty DB) to version 1:
+	VersionScript({
+		"CREATE TABLE IF NOT EXISTS SongHashes ("
+			"FileName TEXT,"
+			"FileSize NUMBER,"
+			"Hash     BLOB"
+		")",
+
+		"CREATE TABLE IF NOT EXISTS SongMetadata ("
+			"Hash                      BLOB PRIMARY KEY,"
+			"Length                    NUMERIC,"
+			"ManualAuthor              TEXT,"
+			"ManualTitle               TEXT,"
+			"ManualGenre               TEXT,"
+			"ManualMeasuresPerMinute   NUMERIC,"
+			"FileNameAuthor            TEXT,"
+			"FileNameTitle             TEXT,"
+			"FileNameGenre             TEXT,"
+			"FileNameMeasuresPerMinute NUMERIC,"
+			"ID3Author                 TEXT,"
+			"ID3Title                  TEXT,"
+			"ID3Genre                  TEXT,"
+			"ID3MeasuresPerMinute      NUMERIC,"
+			"LastPlayed                DATETIME,"
+			"Rating                    NUMERIC,"
+			"LastMetadataUpdated       DATETIME"
+		")",
+
+		"CREATE TABLE IF NOT EXISTS PlaybackHistory ("
+			"SongHash  BLOB,"
+			"Timestamp DATETIME"
+		")",
+
+		"CREATE TABLE IF NOT EXISTS Templates ("
+			"RowID       INTEGER PRIMARY KEY,"
+			"DisplayName TEXT,"
+			"Notes       TEXT,"
+			"BgColor     TEXT"  // "#rrggbb"
+		")",
+
+		"CREATE TABLE IF NOT EXISTS TemplateItems ("
+			"RowID         INTEGER PRIMARY KEY,"
+			"TemplateID    INTEGER,"
+			"IndexInParent INTEGER,"  // The index of the Item within its Template
+			"DisplayName   TEXT,"
+			"Notes         TEXT,"
+			"IsFavorite    INTEGER,"
+			"BgColor       TEXT"  // "#rrggbb"
+		")",
+
+		"CREATE TABLE IF NOT EXISTS TemplateFilters ("
+			"RowID        INTEGER PRIMARY KEY,"
+			"ItemID       INTEGER,"  // RowID of the TemplateItem that owns this filter
+			"TemplateID   INTEGER,"  // RowID of the Template that owns this filter's item
+			"ParentID     INTEGER,"  // RowID of this filter's parent, or -1 if root
+			"Kind         INTEGER,"  // Numeric representation of the Template::Filter::Kind enum
+			"SongProperty INTEGER,"  // Numeric representation of the Template::Filter::SongProperty enum
+			"Comparison   INTEGER,"  // Numeric representation of the Template::Filter::Comparison enum
+			"Value        TEXT"     // The value against which to compare
+		")",
+
+		"CREATE TABLE IF NOT EXISTS Version ("
+			"Version INTEGER"
+		")",
+
+		"INSERT INTO Version (Version) VALUES (1)",
+	}),  // Version 0
+
+
+	#if 0  // This is a preparation for #94 DB reorganization
+	// Version 1 to Version 2:
+	VersionScript({
+		"CREATE TABLE SongFiles AS SELECT "
+		"SongHashes.FileName AS FileName, SongHashes.FileSize AS FileSize, SongHashes.Hash AS Hash,"
+		"SongMetadata.ManualAuthor AS ManualAuthor, SongMetadata.ManualTitle AS ManualTitle, SongMetadata.ManualGenre AS ManualGenre, SongMetadata.ManualMeasuresPerMinute AS ManualMeasuresPerMinute,"
+		"SongMetadata.FileNameAuthor AS FileNameAuthor, SongMetadata.FileNameTitle AS FileNameTitle, SongMetadata.FileNameGenre AS FileNameGenre, SongMetadata.FileNameMeasuresPerMinute AS FileNameMeasuresPerMinute,"
+		"SongMetadata.ID3Author AS ID3Author, SongMetadata.ID3Title AS ID3Title, SongMetadata.ID3Genre AS ID3Genre, SongMetadata.ID3MeasuresPerMinute AS ID3MeasuresPerMinute "
+		"FROM SongHashes LEFT JOIN SongMetadata ON SongHashes.Hash == SongMetadata.Hash",
+
+		"CREATE TABLE NewSongMetadata AS SELECT "
+		"Hash, Length, LastPlayed, Rating, LastMetadataUpdated "
+		"FROM SongMetadata",
+
+		"DROP TABLE SongMetadata",
+
+		"ALTER TABLE NewSongMetadata RENAME TO SongMetadata",
+	}),
+	#endif
+};
+
+
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+// DatabaseUpgrade:
+
+DatabaseUpgrade::DatabaseUpgrade(Database & a_DB):
+	m_DB(a_DB.database())
+{
+}
+
+
+
+
+
+void DatabaseUpgrade::upgrade(Database & a_DB)
+{
+	DatabaseUpgrade upg(a_DB);
+	return upg.execute();
+}
+
+
+
+
+
+void DatabaseUpgrade::execute()
+{
+	auto version = getVersion();
+	qDebug() << "DB is at version " << version;
+	for (auto i = version; i < g_VersionScripts.size(); ++i)
+	{
+		qWarning() << "Upgrading DB to version" << i + 1;
+		g_VersionScripts[i].apply(m_DB, i + 1);
+	}
+}
+
+
+
+
+
+size_t DatabaseUpgrade::getVersion()
+{
+	auto query = m_DB.exec("SELECT MAX(Version) AS Version FROM Version");
+	if (!query.first())
+	{
+		return 0;
+	}
+	return query.record().value("Version").toULongLong();
+}
+
+
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+// DatabaseUpgrade::SqlError:
+
+DatabaseUpgrade::SqlError::SqlError(const QSqlError & a_SqlError, const std::string & a_SqlCommand):
+	Super((std::string("DatabaseUpgrade::SqlError: ") + a_SqlError.text().toStdString()).c_str()),
+	m_Error(a_SqlError),
+	m_Command(a_SqlCommand)
+{
+}

--- a/DatabaseUpgrade.h
+++ b/DatabaseUpgrade.h
@@ -1,0 +1,88 @@
+#ifndef DATABASEUPGRADE_H
+#define DATABASEUPGRADE_H
+
+
+
+
+
+#include <stdexcept>
+#include <string>
+#include <QSqlError>
+
+
+
+
+
+// fwd:
+class Database;
+class QSqlDatabase;
+
+
+
+
+
+class DatabaseUpgrade
+{
+public:
+
+	/** An exception that is thrown on upgrade error. */
+	class Error:
+		public std::runtime_error
+	{
+		using Super = std::runtime_error;
+
+	public:
+		Error(const char * a_What):
+			Super(a_What)
+		{
+		}
+	};
+
+
+	/** An exception that is thrown on upgrade error if the SQL command fails. */
+	class SqlError:
+		public Error
+	{
+		using Super = Error;
+
+	public:
+		/** Creates a new instance, based on the SQL error reported for the command. */
+		SqlError(const QSqlError & a_SqlError, const std::string & a_SqlCommand);
+
+		/** The error reported by the SQL engine. */
+		const QSqlError m_Error;
+
+		/** The command that caused the error. */
+		const std::string m_Command;
+	};
+
+
+	/** Upgrades the database to the latest known version.
+	May throw Error if the upgrade fails.
+	Tries its best to keep the DB in a usable state, even if the upgrade fails. */
+	static void upgrade(Database & a_DB);
+
+
+protected:
+
+
+	/** The SQL database on which to perform the upgrade. */
+	QSqlDatabase & m_DB;
+
+
+	/** Creates a new instance of this object. */
+	DatabaseUpgrade(Database & a_DB);
+
+	/** Performs the whole upgrade on m_DB. */
+	void execute();
+
+	/** Returns the version stored in the DB.
+	If the DB contains no versioning data, returns 0. */
+	size_t getVersion();
+};
+
+
+
+
+
+#endif // DATABASEUPGRADE_H

--- a/HashCalculator.cpp
+++ b/HashCalculator.cpp
@@ -44,7 +44,7 @@ void HashCalculator::queueHashSong(SongPtr a_Song)
 				return;
 			}
 			a_Song->setHash(ch.result());
-			emit this->songHashCalculated(a_Song);
+			emit songHashCalculated(a_Song);
 		}
 	);
 }

--- a/Playlist.cpp
+++ b/Playlist.cpp
@@ -280,7 +280,7 @@ int Playlist::getSongWeight(const Database & a_DB, const Song & a_Song)
 	auto rating = a_Song.rating();
 	if (rating.isValid())
 	{
-		res = res * (rating.toInt() + 1) / 5;  // Even zero-rating songs need *some* chance
+		res = res * (rating.toDouble() + 1) / 5;  // Even zero-rating songs need *some* chance
 	}
 	else
 	{

--- a/SkauTan.pro
+++ b/SkauTan.pro
@@ -88,6 +88,7 @@ SOURCES += \
 	BackgroundTasks.cpp \
 	DlgBackgroundTaskList.cpp \
 	WaveformDisplay.cpp \
+	DatabaseUpgrade.cpp \
 
 HEADERS += \
 	PlayerWindow.h \
@@ -121,6 +122,7 @@ HEADERS += \
 	BackgroundTasks.h \
 	DlgBackgroundTaskList.h \
 	WaveformDisplay.h \
+	DatabaseUpgrade.h \
 
 FORMS += \
 	PlayerWindow.ui \

--- a/SongModel.cpp
+++ b/SongModel.cpp
@@ -55,11 +55,12 @@ static QString formatLastPlayed(const Song & a_Song)
 
 static QString formatRating(const Song & a_Song)
 {
-	if (!a_Song.rating().isValid())
+	const auto & rating = a_Song.rating();
+	if (!rating.isValid())
 	{
 		return SongModel::tr("<none>", "Rating");
 	}
-	return QString::number(a_Song.rating().toDouble(), 'f', 1);
+	return QString::number(rating.toDouble(), 'f', 1);
 }
 
 

--- a/main.cpp
+++ b/main.cpp
@@ -58,7 +58,7 @@ int main(int argc, char *argv[])
 		// Connect the main objects together:
 		app.connect(&mainDB,   &Database::needSongHash,             &hashCalc, &HashCalculator::queueHashSong);
 		app.connect(&hashCalc, &HashCalculator::songHashCalculated, &mainDB,  &Database::songHashCalculated);
-		app.connect(&mainDB,   &Database::needSongMetadata,         &scanner, &MetadataScanner::queueScanSong);
+		app.connect(&mainDB,   &Database::needSongTagRescan,        &scanner, &MetadataScanner::queueScanSong);
 		app.connect(&scanner,  &MetadataScanner::songScanned,       &mainDB,  &Database::songScanned);
 		app.connect(&player,   &Player::startedPlayback, [&](IPlaylistItemPtr a_Item)
 			{
@@ -77,16 +77,16 @@ int main(int argc, char *argv[])
 		// Show the UI:
 		PlayerWindow w(mainDB, scanner, player);
 		w.showMaximized();
+
+		return app.exec();
 	}
 	catch (const std::runtime_error & exc)
 	{
 		QMessageBox::warning(
 			nullptr,
 			app.tr("SkauTan: Fatal error"),
-			app.tr("Cannot start SkauTan, a fatal error has occurred: %1").arg(exc.what())
+			app.tr("SkauTan has detected a fatal error:\n\n%1").arg(exc.what())
 		);
 		return -1;
 	}
-
-	return app.exec();
 }


### PR DESCRIPTION
Data in the DB (and in-memory) is now split between per-file data (`Song` class instances) and per-song data (`Song::SharedData` instances). Multiple files may share the same SharedData (if their hash is the same).

Fixes #94.