### PR TITLE
Add DebugLog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,6 +186,12 @@ endif ()
 add_definitions(-DQT_DEPRECATED_WARNINGS)
 add_definitions(-DTAGLIB_STATIC)
 
+# Enable message log context information even in Release builds:
+add_definitions(-DQT_MESSAGELOGCONTEXT)
+
+
+
+
 
 set (SOURCES
 	# Audio-related sources:
@@ -218,6 +224,7 @@ set (SOURCES
 	# UI Dialog-related sources:
 	src/UI/Dlg/DlgBackgroundTaskList.cpp
 	src/UI/Dlg/DlgChooseImportTemplates.cpp
+	src/UI/Dlg/DlgDebugLog.cpp
 	src/UI/Dlg/DlgEditFilter.cpp
 	src/UI/Dlg/DlgHistory.cpp
 	src/UI/Dlg/DlgImportDB.cpp
@@ -235,6 +242,7 @@ set (SOURCES
 	# Other sources:
 	src/BackgroundTasks.cpp
 	src/ComponentCollection.cpp
+	src/DebugLogger.cpp
 	src/DJControllers.cpp
 	src/Filter.cpp
 	src/InstallConfiguration.cpp
@@ -291,6 +299,7 @@ set (HEADERS
 	# UI Dialog-related headers:
 	src/UI/Dlg/DlgBackgroundTaskList.hpp
 	src/UI/Dlg/DlgChooseImportTemplates.hpp
+	src/UI/Dlg/DlgDebugLog.hpp
 	src/UI/Dlg/DlgEditFilter.hpp
 	src/UI/Dlg/DlgHistory.hpp
 	src/UI/Dlg/DlgImportDB.hpp
@@ -308,6 +317,7 @@ set (HEADERS
 	# Other headers:
 	src/BackgroundTasks.hpp
 	src/ComponentCollection.hpp
+	src/DebugLogger.hpp
 	src/DJControllers.hpp
 	src/DatedOptional.hpp
 	src/Exception.hpp
@@ -332,6 +342,7 @@ set (UI
 	src/UI/PlayerWindow.ui
 	src/UI/Dlg/DlgBackgroundTaskList.ui
 	src/UI/Dlg/DlgChooseImportTemplates.ui
+	src/UI/Dlg/DlgDebugLog.ui
 	src/UI/Dlg/DlgEditFilter.ui
 	src/UI/Dlg/DlgHistory.ui
 	src/UI/Dlg/DlgImportDB.ui

--- a/src/DebugLogger.cpp
+++ b/src/DebugLogger.cpp
@@ -1,0 +1,78 @@
+#include "DebugLogger.hpp"
+#include <QDebug>
+
+
+
+
+
+/** The previous message handler. */
+static QtMessageHandler g_OldHandler;
+
+
+
+
+
+DebugLogger::DebugLogger()
+{
+	g_OldHandler = qInstallMessageHandler(messageHandler);
+}
+
+
+
+
+
+DebugLogger & DebugLogger::get()
+{
+	static DebugLogger inst;
+	return inst;
+}
+
+
+
+
+
+std::vector<DebugLogger::Message> DebugLogger::lastMessages() const
+{
+	QMutexLocker lock(&m_Mtx);
+	std::vector<Message> res;
+	size_t max = sizeof(m_Messages) / sizeof(m_Messages[0]);
+	res.reserve(max);
+	for (size_t i = 0; i < max; ++i)
+	{
+		size_t idx = (i + m_NextMessageIdx) % max;
+		if (m_Messages[idx].m_DateTime.isValid())
+		{
+			res.push_back(m_Messages[idx]);
+		}
+	}
+	return res;
+}
+
+
+
+
+
+void DebugLogger::messageHandler(
+	QtMsgType a_Type,
+	const QMessageLogContext & a_Context,
+	const QString & a_Message
+)
+{
+	DebugLogger::get().addMessage(a_Type, a_Context, a_Message);
+	g_OldHandler(a_Type, a_Context, a_Message);
+}
+
+
+
+
+
+void DebugLogger::addMessage(
+	QtMsgType a_Type,
+	const QMessageLogContext & a_Context,
+	const QString & a_Message
+)
+{
+	QMutexLocker lock(&m_Mtx);
+	m_Messages[m_NextMessageIdx] = Message(a_Type, a_Context, a_Message);
+	m_NextMessageIdx = (m_NextMessageIdx + 1) % (sizeof(m_Messages) / sizeof(m_Messages[0]));
+}

--- a/src/DebugLogger.hpp
+++ b/src/DebugLogger.hpp
@@ -1,0 +1,112 @@
+#ifndef DEBUGLOGGER_HPP
+#define DEBUGLOGGER_HPP
+
+
+
+
+
+#include <QObject>
+#include <QMutex>
+#include <QDateTime>
+
+
+
+
+
+class DebugLogger:
+	public QObject
+{
+	using Super = QObject;
+
+	Q_OBJECT
+
+
+public:
+
+	/** Container for a single debug message. */
+	struct Message
+	{
+		QDateTime m_DateTime;
+		QtMsgType m_Type;
+		QString m_FileName;
+		QString m_Function;
+		int m_LineNum;
+		QString m_Message;
+
+
+		/** Default constructor, used for array initialization.
+		The m_DateTime is not assigned -> it will not be included in lastMessages() output. */
+		Message() = default;
+
+
+		/** Full constructor, used for copying. */
+		Message(
+			QtMsgType a_Type,
+			const QMessageLogContext & a_Context,
+			const QString & a_Message
+		):
+			m_DateTime(QDateTime::currentDateTimeUtc()),
+			m_Type(a_Type),
+			m_FileName(QString::fromUtf8(a_Context.file)),
+			m_Function(QString::fromUtf8(a_Context.function)),
+			m_LineNum(a_Context.line),
+			m_Message(a_Message)
+		{
+		}
+	};
+
+
+	/** Returns the only instance of this object. */
+	static DebugLogger & get();
+
+	/** Returns the (valid) messages stored in the logger. */
+	std::vector<Message> lastMessages() const;
+
+
+signals:
+
+
+public slots:
+
+
+protected:
+
+	/** The maximum count of messages remembered. */
+	static const size_t MAX_MESSAGES = 1024;
+
+	/** The last messages sent to the logger.
+	Protected by m_Mtx against multithreaded access.
+	Works as a circular buffer, with m_NextMessageIdx pointing to the index where the next message will be written. */
+	Message m_Messages[MAX_MESSAGES];
+
+	/** Index into m_Messages where the next message will be written.
+	Protected by m_Mtx against multithreaded access. */
+	size_t m_NextMessageIdx;
+
+	/** The mutex protecting m_Messages and m_NextMessageIdx from multithreaded access. */
+	mutable QMutex m_Mtx;
+
+
+	/** Constructor not accessible to the outside -> singleton. */
+	DebugLogger();
+
+	/** The override message handler that stores messages in a DebugLogger. */
+	static void messageHandler(
+		QtMsgType a_Type,
+		const QMessageLogContext & a_Context,
+		const QString & a_Message
+	);
+
+	/** Adds the specified message to m_Messages[]. */
+	void addMessage(
+		QtMsgType a_Type,
+		const QMessageLogContext & a_Context,
+		const QString & a_Message
+	);
+};
+
+
+
+
+
+#endif // DEBUGLOGGER_HPP

--- a/src/UI/Dlg/DlgDebugLog.cpp
+++ b/src/UI/Dlg/DlgDebugLog.cpp
@@ -1,0 +1,67 @@
+#include "DlgDebugLog.hpp"
+#include "ui_DlgDebugLog.h"
+#include "../../Settings.hpp"
+#include "../../DebugLogger.hpp"
+
+
+
+
+
+DlgDebugLog::DlgDebugLog(QWidget * a_Parent):
+	Super(a_Parent),
+	m_UI(new Ui::DlgDebugLog)
+{
+	m_UI->setupUi(this);
+	Settings::loadWindowPos("DlgDebugLog", *this);
+	Settings::loadHeaderView("DlgDebugLog", "twMessages", *(m_UI->twMessages->horizontalHeader()));
+
+	// Connect the signals:
+	connect(m_UI->btnClose, &QPushButton::clicked, this, &QDialog::close);
+
+	// Insert debug messages:
+	const auto & msgs = DebugLogger::get().lastMessages();
+	for (const auto & msg: msgs)
+	{
+		addMessage(msg.m_DateTime, msg.m_Type, msg.m_FileName, msg.m_Function, msg.m_LineNum, msg.m_Message);
+	}
+
+	// Make the dialog have Maximize button on Windows:
+	setWindowFlags(Qt::Window);
+}
+
+
+
+
+
+DlgDebugLog::~DlgDebugLog()
+{
+	Settings::saveHeaderView("DlgDebugLog", "twMessages", *(m_UI->twMessages->horizontalHeader()));
+	Settings::saveWindowPos("DlgDebugLog", *this);
+}
+
+
+
+
+
+void DlgDebugLog::addMessage(const QDateTime & a_DateTime, const QtMsgType a_Type, const QString & a_FileName, const QString & a_Function, int a_LineNum, const QString & a_Message)
+{
+	auto row = m_UI->twMessages->rowCount();
+	m_UI->twMessages->setRowCount(row + 1);
+
+	QString typeString;
+	switch (a_Type)
+	{
+		case QtDebugMsg:    typeString = "D"; break;
+		case QtInfoMsg:     typeString = "I"; break;
+		case QtWarningMsg:  typeString = "W"; break;
+		case QtCriticalMsg: typeString = "C"; break;
+		case QtFatalMsg:    typeString = "F"; break;
+	}
+	QString lineNumber = (a_LineNum > 0) ? QString::number(a_LineNum) : QString();
+	m_UI->twMessages->setItem(row, 0, new QTableWidgetItem(a_DateTime.toString("yyyy-dd-MM hh:mm:ss")));
+	m_UI->twMessages->setItem(row, 1, new QTableWidgetItem(typeString));
+	m_UI->twMessages->setItem(row, 2, new QTableWidgetItem(a_FileName));
+	m_UI->twMessages->setItem(row, 3, new QTableWidgetItem(a_Function));
+	m_UI->twMessages->setItem(row, 4, new QTableWidgetItem(QString::number(a_LineNum)));
+	m_UI->twMessages->setItem(row, 5, new QTableWidgetItem(a_Message));
+}

--- a/src/UI/Dlg/DlgDebugLog.hpp
+++ b/src/UI/Dlg/DlgDebugLog.hpp
@@ -1,0 +1,60 @@
+#ifndef DLGDEBUGLOG_HPP
+#define DLGDEBUGLOG_HPP
+
+
+
+
+
+#include <memory>
+#include <QDialog>
+
+
+
+
+
+namespace Ui
+{
+	class DlgDebugLog;
+}
+
+
+
+
+
+/** Dialog that displays the DebugLogger's messages in a table. */
+class DlgDebugLog:
+	public QDialog
+{
+	using Super = QDialog;
+
+	Q_OBJECT
+
+public:
+
+	explicit DlgDebugLog(QWidget * a_Parent = nullptr);
+
+	~DlgDebugLog();
+
+
+private:
+
+	/** The Qt-managed UI. */
+	std::unique_ptr<Ui::DlgDebugLog> m_UI;
+
+
+	/** Adds the specified message to twMessages. */
+	void addMessage(
+		const QDateTime & a_DateTime,
+		const QtMsgType a_Type,
+		const QString & a_FileName,
+		const QString & a_Function,
+		int a_LineNum,
+		const QString & a_Message
+	);
+};
+
+
+
+
+
+#endif // DLGDEBUGLOG_HPP

--- a/src/UI/Dlg/DlgDebugLog.ui
+++ b/src/UI/Dlg/DlgDebugLog.ui
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>DlgDebugLog</class>
+ <widget class="QDialog" name="DlgDebugLog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>681</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>SkauTan: DebugLog</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QTableWidget" name="twMessages">
+     <property name="verticalScrollBarPolicy">
+      <enum>Qt::ScrollBarAlwaysOn</enum>
+     </property>
+     <property name="horizontalScrollMode">
+      <enum>QAbstractItemView::ScrollPerPixel</enum>
+     </property>
+     <property name="wordWrap">
+      <bool>false</bool>
+     </property>
+     <attribute name="horizontalHeaderHighlightSections">
+      <bool>false</bool>
+     </attribute>
+     <attribute name="verticalHeaderVisible">
+      <bool>false</bool>
+     </attribute>
+     <attribute name="verticalHeaderDefaultSectionSize">
+      <number>21</number>
+     </attribute>
+     <attribute name="verticalHeaderMinimumSectionSize">
+      <number>15</number>
+     </attribute>
+     <column>
+      <property name="text">
+       <string>Date</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Type</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>File</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Function</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Line</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Message</string>
+      </property>
+     </column>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnClose">
+       <property name="text">
+        <string>&amp;Close</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/UI/PlayerWindow.cpp
+++ b/src/UI/PlayerWindow.cpp
@@ -30,6 +30,7 @@
 #include "Dlg/DlgImportDB.hpp"
 #include "Dlg/DlgLvsStatus.hpp"
 #include "Dlg/DlgLibraryMaintenance.hpp"
+#include "Dlg/DlgDebugLog.hpp"
 
 
 
@@ -111,6 +112,7 @@ PlayerWindow::PlayerWindow(ComponentCollection & a_Components):
 	connect(m_UI->actLoadPlaylist,        &QAction::triggered,                   this,         &PlayerWindow::loadPlaylist);
 	connect(m_UI->actToggleLvs,           &QAction::triggered,                   this,         &PlayerWindow::toggleLvs);
 	connect(m_UI->actLvsStatus,           &QAction::triggered,                   this,         &PlayerWindow::showLvsStatus);
+	connect(m_UI->actShowDebugLog,        &QAction::triggered,                   this,         &PlayerWindow::showDebugLog);
 	connect(m_UI->lwQuickPlay,            &QListWidget::itemClicked,             this,         &PlayerWindow::quickPlayItemClicked);
 	connect(m_PlaylistDelegate.get(),     &PlaylistItemDelegate::replaceSong,    this,         &PlayerWindow::replaceSong);
 	connect(m_UI->tblPlaylist,            &QWidget::customContextMenuRequested,  this,         &PlayerWindow::showPlaylistContextMenu);
@@ -172,6 +174,8 @@ PlayerWindow::PlayerWindow(ComponentCollection & a_Components):
 	menu->addSeparator();
 	menu->addAction(m_UI->actToggleLvs);
 	menu->addAction(m_UI->actLvsStatus);
+	menu->addSeparator();
+	menu->addAction(m_UI->actShowDebugLog);
 	m_UI->btnTools->setMenu(menu);
 
 	// Add the context-menu actions to their respective controls, so that their shortcuts work:
@@ -192,6 +196,7 @@ PlayerWindow::PlayerWindow(ComponentCollection & a_Components):
 		m_UI->actLoadPlaylist,
 		m_UI->actToggleLvs,
 		m_UI->actLvsStatus,
+		m_UI->actShowDebugLog,
 	});
 
 	refreshQuickPlay();
@@ -1140,5 +1145,15 @@ void PlayerWindow::djControllerNavigateDown()
 void PlayerWindow::showLvsStatus()
 {
 	DlgLvsStatus dlg(m_Components, this);
+	dlg.exec();
+}
+
+
+
+
+
+void PlayerWindow::showDebugLog()
+{
+	DlgDebugLog dlg(this);
 	dlg.exec();
 }

--- a/src/UI/PlayerWindow.hpp
+++ b/src/UI/PlayerWindow.hpp
@@ -232,6 +232,9 @@ private slots:
 
 	/** Shows the status dialog for the LocalVoteServer. */
 	void showLvsStatus();
+
+	/** Shows the DebugLog dialog. */
+	void showDebugLog();
 };
 
 

--- a/src/UI/PlayerWindow.ui
+++ b/src/UI/PlayerWindow.ui
@@ -687,6 +687,14 @@
     <string>Load a playlist from a file, insert after the current selection</string>
    </property>
   </action>
+  <action name="actShowDebugLog">
+   <property name="text">
+    <string>Show DebugLog...</string>
+   </property>
+   <property name="toolTip">
+    <string>Shows the debug messages recorded so far</string>
+   </property>
+  </action>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,6 +20,7 @@
 #include "DJControllers.hpp"
 #include "LocalVoteServer.hpp"
 #include "InstallConfiguration.hpp"
+#include "DebugLogger.hpp"
 
 
 
@@ -116,6 +117,9 @@ void importDefaultTemplates(Database & a_DB)
 
 int main(int argc, char *argv[])
 {
+	// Initialize the DebugLogger:
+	DebugLogger::get();
+
 	QApplication app(argc, argv);
 
 	try

--- a/translations/SkauTan_cs.ts
+++ b/translations/SkauTan_cs.ts
@@ -123,6 +123,49 @@
     </message>
 </context>
 <context>
+    <name>DlgDebugLog</name>
+    <message>
+        <location filename="../src/UI/Dlg/DlgDebugLog.ui" line="14"/>
+        <source>SkauTan: DebugLog</source>
+        <translation>SkauTan: DebugLog</translation>
+    </message>
+    <message>
+        <location filename="../src/UI/Dlg/DlgDebugLog.ui" line="42"/>
+        <source>Date</source>
+        <translation>Datum</translation>
+    </message>
+    <message>
+        <location filename="../src/UI/Dlg/DlgDebugLog.ui" line="47"/>
+        <source>Type</source>
+        <translation>Typ</translation>
+    </message>
+    <message>
+        <location filename="../src/UI/Dlg/DlgDebugLog.ui" line="52"/>
+        <source>File</source>
+        <translation>Soubor</translation>
+    </message>
+    <message>
+        <location filename="../src/UI/Dlg/DlgDebugLog.ui" line="57"/>
+        <source>Function</source>
+        <translation>Funkce</translation>
+    </message>
+    <message>
+        <location filename="../src/UI/Dlg/DlgDebugLog.ui" line="62"/>
+        <source>Line</source>
+        <translation>Řádek</translation>
+    </message>
+    <message>
+        <location filename="../src/UI/Dlg/DlgDebugLog.ui" line="67"/>
+        <source>Message</source>
+        <translation>Zpráva</translation>
+    </message>
+    <message>
+        <location filename="../src/UI/Dlg/DlgDebugLog.ui" line="90"/>
+        <source>&amp;Close</source>
+        <translation>&amp;Zavřít</translation>
+    </message>
+</context>
+<context>
     <name>DlgEditFilter</name>
     <message>
         <location filename="../src/UI/Dlg/DlgEditFilter.ui" line="14"/>
@@ -994,7 +1037,7 @@
     <message>
         <location filename="../src/UI/Dlg/DlgRemovedSongs.ui" line="36"/>
         <source>Date</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Datum</translation>
     </message>
     <message>
         <location filename="../src/UI/Dlg/DlgRemovedSongs.ui" line="41"/>
@@ -2632,21 +2675,31 @@ Tato operace je nevratná!</translation>
         <translation>Načte playlist ze souboru a vloží jej za aktuálně označenou skladbu</translation>
     </message>
     <message>
+        <location filename="../src/UI/PlayerWindow.ui" line="692"/>
+        <source>Show DebugLog...</source>
+        <translation>Zobrazit DebugLog...</translation>
+    </message>
+    <message>
+        <location filename="../src/UI/PlayerWindow.ui" line="695"/>
+        <source>Shows the debug messages recorded so far</source>
+        <translation>Zobrazí dialog s výpisem ladících zpráv</translation>
+    </message>
+    <message>
         <source>Background tasks</source>
         <translation type="vanished">Úlohy na pozadí</translation>
     </message>
     <message>
-        <location filename="../src/UI/PlayerWindow.cpp" line="287"/>
+        <location filename="../src/UI/PlayerWindow.cpp" line="292"/>
         <source>Songs: %1</source>
         <translation>Skladeb: %1</translation>
     </message>
     <message>
-        <location filename="../src/UI/PlayerWindow.cpp" line="677"/>
+        <location filename="../src/UI/PlayerWindow.cpp" line="682"/>
         <source>SkauTan: Delete songs?</source>
         <translation>SkauTan: vymazat skladby?</translation>
     </message>
     <message>
-        <location filename="../src/UI/PlayerWindow.cpp" line="678"/>
+        <location filename="../src/UI/PlayerWindow.cpp" line="683"/>
         <source>Are you sure you want to delete the selected songs from the disk?The files will be deleted and all properties set in the library will be lost.
 
 This operation cannot be undone!</source>
@@ -2655,12 +2708,12 @@ This operation cannot be undone!</source>
 Tato operace je nevratná!</translation>
     </message>
     <message>
-        <location filename="../src/UI/PlayerWindow.cpp" line="712"/>
+        <location filename="../src/UI/PlayerWindow.cpp" line="717"/>
         <source>SkauTan: Remove songs?</source>
         <translation>SkauTan: Odebrat skladby?</translation>
     </message>
     <message>
-        <location filename="../src/UI/PlayerWindow.cpp" line="713"/>
+        <location filename="../src/UI/PlayerWindow.cpp" line="718"/>
         <source>Are you sure you want to remove the selected songs from the library? The song files will stay on the disk, but all properties set in the library will be lost.
 
 This operation cannot be undone!</source>
@@ -2669,38 +2722,38 @@ This operation cannot be undone!</source>
 Tato operace je nevratná!</translation>
     </message>
     <message>
-        <location filename="../src/UI/PlayerWindow.cpp" line="827"/>
+        <location filename="../src/UI/PlayerWindow.cpp" line="832"/>
         <source>SkauTan: Set duration limit</source>
         <translation>SkauTan: Nastavit limit</translation>
     </message>
     <message>
-        <location filename="../src/UI/PlayerWindow.cpp" line="828"/>
+        <location filename="../src/UI/PlayerWindow.cpp" line="833"/>
         <source>New duration:</source>
         <translation>Nový limit:</translation>
     </message>
     <message>
-        <location filename="../src/UI/PlayerWindow.cpp" line="995"/>
+        <location filename="../src/UI/PlayerWindow.cpp" line="1000"/>
         <source>SkauTan: Save playlist</source>
         <translation>SkauTan: Uložit playlist</translation>
     </message>
     <message>
-        <location filename="../src/UI/PlayerWindow.cpp" line="1011"/>
+        <location filename="../src/UI/PlayerWindow.cpp" line="1016"/>
         <source>SkauTan: Cannot save playlist</source>
         <translation>SkauTan: Nelze uložit playlist</translation>
     </message>
     <message>
-        <location filename="../src/UI/PlayerWindow.cpp" line="1012"/>
-        <location filename="../src/UI/PlayerWindow.cpp" line="1046"/>
+        <location filename="../src/UI/PlayerWindow.cpp" line="1017"/>
+        <location filename="../src/UI/PlayerWindow.cpp" line="1051"/>
         <source>Cannot save playlist to file %1: %2</source>
         <translation>Nelze uložit playlist do souboru %1: %2</translation>
     </message>
     <message>
-        <location filename="../src/UI/PlayerWindow.cpp" line="1025"/>
+        <location filename="../src/UI/PlayerWindow.cpp" line="1030"/>
         <source>SkauTan: Load playlist</source>
         <translation>SkauTan: Načíst playlist</translation>
     </message>
     <message>
-        <location filename="../src/UI/PlayerWindow.cpp" line="1045"/>
+        <location filename="../src/UI/PlayerWindow.cpp" line="1050"/>
         <source>SkauTan: Cannot load playlist</source>
         <translation>SkauTan: Nelze načíst playlist</translation>
     </message>
@@ -2709,8 +2762,8 @@ Tato operace je nevratná!</translation>
         <translation type="vanished">SkauTan: Uložit playlist:</translation>
     </message>
     <message>
-        <location filename="../src/UI/PlayerWindow.cpp" line="997"/>
-        <location filename="../src/UI/PlayerWindow.cpp" line="1027"/>
+        <location filename="../src/UI/PlayerWindow.cpp" line="1002"/>
+        <location filename="../src/UI/PlayerWindow.cpp" line="1032"/>
         <source>M3U playlist (*.m3u)</source>
         <translation>Playlist M3U (*.m3u)</translation>
     </message>
@@ -2827,25 +2880,25 @@ Tato operace je nevratná!</translation>
 <context>
     <name>QApplication</name>
     <message>
-        <location filename="../src/main.cpp" line="99"/>
+        <location filename="../src/main.cpp" line="100"/>
         <source>SkauTan: Error</source>
         <translation>SkauTan: Chyba</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="100"/>
+        <location filename="../src/main.cpp" line="101"/>
         <source>Cannot import default templates, the definition file is inaccessible.
 %1</source>
         <translation>Nelze importovat vestavěné šablony, definice není přístupná.
 %1</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="204"/>
-        <location filename="../src/main.cpp" line="213"/>
+        <location filename="../src/main.cpp" line="208"/>
+        <location filename="../src/main.cpp" line="217"/>
         <source>SkauTan: Fatal error</source>
         <translation>SkauTan: Chyba</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="205"/>
+        <location filename="../src/main.cpp" line="209"/>
         <source>SkauTan has detected a fatal error:
 
 %1</source>
@@ -2854,7 +2907,7 @@ Tato operace je nevratná!</translation>
 %1</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="214"/>
+        <location filename="../src/main.cpp" line="218"/>
         <source>SkauTan has detected an unknown fatal error. Use a debugger to view detailed runtime log.</source>
         <translation>SkauTan detekoval neznámou chybu. Použijte debugger pro zobrazení detailního logu.</translation>
     </message>


### PR DESCRIPTION
DebugLog is recorded and shown in DlgDebugLog, available from the Tools menu.

Decided not to do a live-view of the messages, at least not yet.

Also it seems impossible to write to a console from a GUI program (`printf` et al don't output anything). If ever needed, we could add DebugLog output to a log file.

Fixes #215.