### PR TITLE
Metadata cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -340,6 +340,10 @@ set (HEADERS
 	src/Utils.hpp
 )
 
+
+
+
+
 set (UI
 	src/UI/ClassroomWindow.ui
 	src/UI/PlayerWindow.ui
@@ -511,6 +515,10 @@ target_link_libraries(BeatDetectCmd
 	$<$<CONFIG:MinSizeRel>:${TAGLIB_RELEASE}>
 )
 
+
+
+
+
 if (MSVC)
 	target_link_libraries(BeatDetectCmd
 		$<$<CONFIG:Debug>:${ZLIB_DEBUG}>
@@ -523,6 +531,7 @@ else ()
 		z
 	)
 endif ()
+
 
 
 
@@ -549,4 +558,47 @@ target_link_libraries(FreqExtract
 	${AVUTIL}
 	${AVCODEC}
 	${SWRESAMPLE}
+)
+
+
+
+
+
+############################################
+# Tests:
+
+enable_testing()
+
+add_executable(TagProcessing
+	tests/TagProcessing.cpp
+	src/MetadataScanner.cpp
+	src/MetadataScanner.hpp
+	src/Song.cpp
+	src/Song.hpp
+)
+
+target_link_libraries (TagProcessing
+	Qt5::Widgets
+	# TagLib libraries (assumed installed on the build system):
+	$<$<CONFIG:Debug>:${TAGLIB_DEBUG}>
+	$<$<CONFIG:Release>:${TAGLIB_RELEASE}>
+	$<$<CONFIG:RelWithDebInfo>:${TAGLIB_RELEASE}>
+	$<$<CONFIG:MinSizeRel>:${TAGLIB_RELEASE}>
+)
+
+if (MSVC)
+	target_link_libraries(TagProcessing
+		$<$<CONFIG:Debug>:${ZLIB_DEBUG}>
+		$<$<CONFIG:Release>:${ZLIB_RELEASE}>
+		$<$<CONFIG:RelWithDebInfo>:${ZLIB_RELEASE}>
+		$<$<CONFIG:MinSizeRel>:${ZLIB_RELEASE}>
+	)
+else ()
+	target_link_libraries(TagProcessing
+		z
+	)
+endif ()
+
+add_test(NAME TagProcessing
+	COMMAND TagProcessing
 )

--- a/src/DatedOptional.hpp
+++ b/src/DatedOptional.hpp
@@ -109,6 +109,22 @@ public:
 		return m_IsPresent;
 	}
 
+	constexpr bool operator == (const DatedOptional<T> & a_Other) const noexcept
+	{
+		return (
+			(m_IsPresent == a_Other.m_IsPresent) &&
+			(
+				!m_IsPresent ||
+				(m_Value == a_Other.m_Value)
+			)
+		);
+	}
+
+	constexpr bool operator != (const DatedOptional<T> & a_Other) const noexcept
+	{
+		return !(operator==(a_Other));
+	}
+
 	constexpr bool isPresent() const noexcept
 	{
 		return m_IsPresent;

--- a/src/MetadataScanner.cpp
+++ b/src/MetadataScanner.cpp
@@ -246,7 +246,7 @@ static QString tryMatchBPM(const QString & a_Input, Song::Tag & a_OutputTag)
 
 
 /** Extracts as much metadata form the input string as possible.
-The extracted data is saved into a_OutputTag and removed from the string. */
+The extracted data is saved into a_OutputTag and, if appropriate, removed from the string. */
 static QString extract(const QString & a_Input, Song::Tag & a_OutputTag)
 {
 	// First process all parentheses, brackets and braces:
@@ -477,36 +477,6 @@ MetadataScanner::Tag MetadataScanner::applyTagChanges(const MetadataScanner::Tag
 
 
 
-void MetadataScanner::enqueueScan(SongPtr a_Song, bool a_Prioritize)
-{
-	m_QueueLength += 1;
-	BackgroundTasks::enqueue(tr("Scan metadata: %1").arg(a_Song->fileName()), [this, a_Song]()
-		{
-			scanSong(a_Song);
-			m_QueueLength -= 1;
-		},
-		a_Prioritize
-	);
-}
-
-
-
-
-
-TagLib::FileRef MetadataScanner::openTagFile(const QString & a_FileName)
-{
-	#ifdef _WIN32
-		// TagLib on Windows needs UTF16-BE filenames (#134):
-		return TagLib::FileRef(reinterpret_cast<const wchar_t *>(a_FileName.constData()), false);
-	#else
-		return TagLib::FileRef(a_FileName.toUtf8().constData(), false);
-	#endif
-}
-
-
-
-
-
 Song::Tag MetadataScanner::parseFileNameIntoMetadata(const QString & a_FileName)
 {
 	Song::Tag songTag;
@@ -553,6 +523,36 @@ Song::Tag MetadataScanner::parseFileNameIntoMetadata(const QString & a_FileName)
 	}
 	validateSongTag(songTag);
 	return songTag;
+}
+
+
+
+
+
+void MetadataScanner::enqueueScan(SongPtr a_Song, bool a_Prioritize)
+{
+	m_QueueLength += 1;
+	BackgroundTasks::enqueue(tr("Scan metadata: %1").arg(a_Song->fileName()), [this, a_Song]()
+		{
+			scanSong(a_Song);
+			m_QueueLength -= 1;
+		},
+		a_Prioritize
+	);
+}
+
+
+
+
+
+TagLib::FileRef MetadataScanner::openTagFile(const QString & a_FileName)
+{
+	#ifdef _WIN32
+		// TagLib on Windows needs UTF16-BE filenames (#134):
+		return TagLib::FileRef(reinterpret_cast<const wchar_t *>(a_FileName.constData()), false);
+	#else
+		return TagLib::FileRef(a_FileName.toUtf8().constData(), false);
+	#endif
 }
 
 

--- a/src/MetadataScanner.hpp
+++ b/src/MetadataScanner.hpp
@@ -10,6 +10,7 @@
 #include <QObject>
 #include "ComponentCollection.hpp"
 #include "Song.hpp"
+#include "DatedOptional.hpp"
 
 
 
@@ -43,9 +44,39 @@ public:
 	{
 		DatedOptional<QString> m_Author;
 		DatedOptional<QString> m_Title;
-		DatedOptional<QString> m_Genre;
 		DatedOptional<QString> m_Comment;
+		DatedOptional<QString> m_Genre;
 		DatedOptional<double>  m_MeasuresPerMinute;
+
+		Tag() = default;
+		Tag(const Tag & a_Other) = default;
+		Tag(
+			const QString & a_Author,
+			const QString & a_Title,
+			const QString & a_Comment,
+			const QString & a_Genre,
+			double a_MeasuresPerMinute
+		):
+			m_Author(a_Author),
+			m_Title(a_Title),
+			m_Comment(a_Comment),
+			m_Genre(a_Genre),
+			m_MeasuresPerMinute(a_MeasuresPerMinute)
+		{
+		}
+
+		Tag(
+			const QString & a_Author,
+			const QString & a_Title,
+			const QString & a_Comment,
+			const QString & a_Genre
+		):
+			m_Author(a_Author),
+			m_Title(a_Title),
+			m_Comment(a_Comment),
+			m_Genre(a_Genre)
+		{
+		}
 	};
 
 
@@ -71,6 +102,11 @@ public:
 	Only values from a_Changes that are present are applied into the result. */
 	static Tag applyTagChanges(const Tag & a_FileTag, const Tag & a_Changes);
 
+	/** Attempts to parse the filename into metadata.
+	Assumes that most of our songs have some info in their filename or the containing folders,
+	tries to extract that info into the returned tag. */
+	static Song::Tag parseFileNameIntoMetadata(const QString & a_FileName);
+
 
 protected:
 
@@ -83,11 +119,6 @@ protected:
 
 	/** Opens the specified file for reading / writing the tag using TagLib. */
 	static TagLib::FileRef openTagFile(const QString & a_FileName);
-
-	/** Attempts to parse the filename into metadata.
-	Assumes that most of our songs have some info in their filename or the containing folders,
-	tries to extract that info into the returned tag. */
-	static Song::Tag parseFileNameIntoMetadata(const QString & a_FileName);
 
 
 signals:

--- a/src/Song.hpp
+++ b/src/Song.hpp
@@ -43,10 +43,60 @@ public:
 	the metadata for each source. */
 	struct Tag
 	{
-		DatedOptional<QString> m_Title;
 		DatedOptional<QString> m_Author;
+		DatedOptional<QString> m_Title;
 		DatedOptional<QString> m_Genre;
 		DatedOptional<double>  m_MeasuresPerMinute;
+
+		Tag() = default;
+		Tag(const Tag & a_Other) = default;
+		Tag(
+			const QString & a_Author,
+			const QString & a_Title,
+			const QString & a_Genre,
+			double a_MeasuresPerMinute
+		):
+			m_Author(a_Author),
+			m_Title(a_Title),
+			m_Genre(a_Genre),
+			m_MeasuresPerMinute(a_MeasuresPerMinute)
+		{
+		}
+
+		Tag(
+			const QString & a_Author,
+			const QString & a_Title,
+			const QString & a_Genre
+		):
+			m_Author(a_Author),
+			m_Title(a_Title),
+			m_Genre(a_Genre)
+		{
+		}
+
+		Tag(
+			const QString & a_Author,
+			const QString & a_Title
+		):
+			m_Author(a_Author),
+			m_Title(a_Title)
+		{
+		}
+
+		constexpr bool operator == (const Tag & a_Other) const noexcept
+		{
+			return (
+				(m_Title == a_Other.m_Title) &&
+				(m_Author == a_Other.m_Author) &&
+				(m_Genre == a_Other.m_Genre) &&
+				(m_MeasuresPerMinute == a_Other.m_MeasuresPerMinute)
+			);
+		}
+
+		constexpr bool operator != (const Tag & a_Other) const noexcept
+		{
+			return !(operator==(a_Other));
+		}
 	};
 
 

--- a/tests/TagProcessing.cpp
+++ b/tests/TagProcessing.cpp
@@ -1,0 +1,191 @@
+// TagProcessing.cpp
+
+// Tests the MetadataScanner's tag processing (FileTag to Song::Tag transformation)
+
+
+
+
+#include <iostream>
+#include "../src/MetadataScanner.hpp"
+#include "../src/BackgroundTasks.hpp"
+
+
+
+
+/** Global failure flag, any failing test sets this to true.
+The program's exit status is set according to this value. */
+static bool g_HasFailed = false;
+
+
+
+
+
+/** Outputs the specified optional value to the stream, saying "(none)" if the value is not present. */
+static std::ostream & operator <<(std::ostream & a_Stream, const DatedOptional<QString> & a_Value)
+{
+	if (!a_Value.isPresent())
+	{
+		a_Stream << "(none)";
+	}
+	else
+	{
+		a_Stream << "\"" << a_Value.value().toStdString() << "\"";
+	}
+	return a_Stream;
+}
+
+
+
+
+
+/** Outputs the specified optional value to the stream, saying "(none)" if the value is not present. */
+static std::ostream & operator <<(std::ostream & a_Stream, const DatedOptional<double> & a_Value)
+{
+	if (!a_Value.isPresent())
+	{
+		a_Stream << "(none)";
+	}
+	else
+	{
+		a_Stream << a_Value.value();
+	}
+	return a_Stream;
+}
+
+
+
+
+
+/** Returns true if the two optional strings are equal.
+Note that equality is rather loose here - an empty DatedOptional matches an empty string. */
+static bool areEqual(const DatedOptional<QString> & a_Value1, const DatedOptional<QString> & a_Value2)
+{
+	if (a_Value1.isEmpty() && a_Value2.isEmpty())
+	{
+		return true;
+	}
+	return (a_Value1.valueOrDefault() == a_Value2.valueOrDefault());
+}
+
+
+
+
+
+/** Returns true if the two tags are equal.
+Note that equality is specific here - an empty DatedOptional matches -1, to simplify writing test values. */
+static bool areEqual(const DatedOptional<double> & a_Value1, const DatedOptional<double> & a_Value2)
+{
+	return (std::abs(a_Value1.valueOr(-1) - a_Value2.valueOr(-1)) < 0.000001);
+}
+
+
+
+
+
+/** Returns true if the two tags are equal.
+Note that equality is rather loose here - an empty DatedOptional matches an empty string, etc. */
+static bool areEqual(const Song::Tag & a_Tag1, const Song::Tag & a_Tag2)
+{
+	return (
+		areEqual(a_Tag1.m_Author,            a_Tag2.m_Author) &&
+		areEqual(a_Tag1.m_Title,             a_Tag2.m_Title) &&
+		areEqual(a_Tag1.m_Genre,             a_Tag2.m_Genre) &&
+		areEqual(a_Tag1.m_MeasuresPerMinute, a_Tag2.m_MeasuresPerMinute)
+	);
+}
+
+
+
+
+
+void testTagParsing(const MetadataScanner::Tag & a_InputTag, const Song::Tag & a_ExpectedOutput)
+{
+	auto parsed = MetadataScanner::parseId3Tag(a_InputTag);
+	if (areEqual(parsed, a_ExpectedOutput))
+	{
+		return;
+	}
+	std::cerr << "Tag parsing failed:" << std::endl;
+	std::cerr << "  Input author:  " << a_InputTag.m_Author << std::endl;
+	std::cerr << "  Input title:   " << a_InputTag.m_Title << std::endl;
+	std::cerr << "  Input comment: " << a_InputTag.m_Comment<< std::endl;
+	std::cerr << "  Input genre:   " << a_InputTag.m_Genre << std::endl;
+	std::cerr << "  Input BPM:     " << a_InputTag.m_MeasuresPerMinute << "\"" << std::endl;
+	std::cerr << "  Parsed author: " << parsed.m_Author << std::endl;
+	std::cerr << "  Parsed title:  " << parsed.m_Title << std::endl;
+	std::cerr << "  Parsed genre:  " << parsed.m_Genre << std::endl;
+	std::cerr << "  Parsed MPM:    " << parsed.m_MeasuresPerMinute << std::endl;
+	std::cerr << "  Expected author: " << a_ExpectedOutput.m_Author << std::endl;
+	std::cerr << "  Expected title:  " << a_ExpectedOutput.m_Title << std::endl;
+	std::cerr << "  Expected genre:  " << a_ExpectedOutput.m_Genre << std::endl;
+	std::cerr << "  Expected MPM:    " << a_ExpectedOutput.m_MeasuresPerMinute << std::endl;
+	g_HasFailed = true;
+}
+
+
+
+
+
+void testFileNameParsing(const QString & a_FileName, const Song::Tag & a_ExpectedOutput)
+{
+	auto parsed = MetadataScanner::parseFileNameIntoMetadata(a_FileName);
+	if (parsed == a_ExpectedOutput)
+	{
+		return;
+	}
+	std::cerr << "FileName parsing failed:" << std::endl;
+	std::cerr << "  Input FileName:  \"" << a_FileName.toStdString() << "\"" << std::endl;
+	std::cerr << "  Parsed author: " << parsed.m_Author << std::endl;
+	std::cerr << "  Parsed title:  " << parsed.m_Title << std::endl;
+	std::cerr << "  Parsed genre:  " << parsed.m_Genre << std::endl;
+	std::cerr << "  Parsed MPM:    " << parsed.m_MeasuresPerMinute << std::endl;
+	std::cerr << "  Expected author: " << a_ExpectedOutput.m_Author << std::endl;
+	std::cerr << "  Expected title:  " << a_ExpectedOutput.m_Title << std::endl;
+	std::cerr << "  Expected genre:  " << a_ExpectedOutput.m_Genre << std::endl;
+	std::cerr << "  Expected MPM:    " << a_ExpectedOutput.m_MeasuresPerMinute << std::endl;
+	g_HasFailed = true;
+}
+
+
+
+
+
+int main()
+{
+	static std::pair<MetadataScanner::Tag, Song::Tag> tagTests[] =
+	{
+		{{"author",          "title", "comment", "slowfox", 50}, {"author", "title", "SF", 50}},
+		{{"-WALTZ   29 BPM", "title", "",        ""},            {"",       "title", "SW", 29}},
+	};
+	for (const auto & test: tagTests)
+	{
+		testTagParsing(test.first, test.second);
+	}
+
+	static std::pair<QString, Song::Tag> fileNameTests[] =
+	{
+		{"waltz/[30 MPM] author - title.mp3",     {"author", "title", "SW", 30}},
+		{"album/author - title (sb50).mp3",       {"author", "title", "SB", 50}},
+		{"album/author - title (slowfox 29).mp3", {"author", "title", "SF", 29}},
+		{"valcik/author - title waltz 60.mp3",    {"author", "title waltz 60", "VW"}},  // A single separate number has no real meaning (track? mpm? index?)
+		{"album/01 unknown1.mp3",                 {"", "unknown1", ""}},
+	};
+	for (const auto & test: fileNameTests)
+	{
+		testFileNameParsing(test.first, test.second);
+	}
+
+	if (!g_HasFailed)
+	{
+		std::cerr << "All tests passed" << std::endl;
+	}
+	return g_HasFailed ? 1 : 0;
+}
+
+
+
+
+// Dummy functions needed to compile the used parts of the sources:
+void BackgroundTasks::enqueue(const QString &, std::function<void()>, bool, std::function<void()>)
+{
+}

--- a/translations/SkauTan_cs.ts
+++ b/translations/SkauTan_cs.ts
@@ -2604,7 +2604,7 @@ Tato operace je nevratná!</translation>
 <context>
     <name>MetadataScanner</name>
     <message>
-        <location filename="../src/MetadataScanner.cpp" line="535"/>
+        <location filename="../src/MetadataScanner.cpp" line="703"/>
         <source>Scan metadata: %1</source>
         <translation>Čtení metadat: %1</translation>
     </message>

--- a/translations/SkauTan_cs.ts
+++ b/translations/SkauTan_cs.ts
@@ -2604,7 +2604,7 @@ Tato operace je nevratná!</translation>
 <context>
     <name>MetadataScanner</name>
     <message>
-        <location filename="../src/MetadataScanner.cpp" line="483"/>
+        <location filename="../src/MetadataScanner.cpp" line="535"/>
         <source>Scan metadata: %1</source>
         <translation>Čtení metadat: %1</translation>
     </message>


### PR DESCRIPTION
Reimplemented metadata scanner tag processing. Now tags are broken into parts by dashes, then each part is processed separately. Author-title splitting is performed when appropriate.

Fixes #227.
