### PR TITLE
Upgrade waveform display

### DIFF
--- a/src/UI/WaveformDisplay.hpp
+++ b/src/UI/WaveformDisplay.hpp
@@ -44,7 +44,7 @@ public:
 	void setPlayer(Player & a_Player);
 
 	/** Paints the display for the specified paint event. */
-	void paint(QPainter & a_Painter, const QPoint & a_Origin, int a_Height);
+	void paint(QPainter & a_Painter, int a_Height);
 
 	/** Sets the new width and height for the display.
 	Recalculates the peaks. */

--- a/src/UI/WaveformDisplay.hpp
+++ b/src/UI/WaveformDisplay.hpp
@@ -99,6 +99,13 @@ protected:
 	virtual void mouseReleaseEvent(QMouseEvent * a_Event) override;
 	virtual void contextMenuEvent(QContextMenuEvent * a_Event) override;
 
+	/** Converts the time within the song into a screen X coord. */
+	int timeToScreen(double a_Seconds);
+
+	/** Converts the screen X coord into timestamp within the song.
+	Clamps the X coord into the valid range, if needed. */
+	double screenToTime(int a_PosX);
+
 
 signals:
 

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -3,6 +3,7 @@
 #include <QDebug>
 #include <QListWidget>
 #include <QByteArray>
+#include <QPainter>
 
 
 
@@ -148,4 +149,33 @@ QString toHex(const QByteArray & a_Data)
 
 
 
+QPainterSaver::QPainterSaver(QPainter & a_Painter):
+	m_Painter(&a_Painter)
+{
+	a_Painter.save();
 }
+
+
+
+
+
+QPainterSaver::QPainterSaver(QPainter * a_Painter):
+	m_Painter(a_Painter)
+{
+	a_Painter->save();
+}
+
+
+
+
+
+QPainterSaver::~QPainterSaver()
+{
+	m_Painter->restore();
+}
+
+
+
+
+
+}  // namespace Utils

--- a/src/Utils.hpp
+++ b/src/Utils.hpp
@@ -10,6 +10,7 @@ class QString;
 class QListWidget;
 class QVariant;
 class QByteArray;
+class QPainter;
 
 
 
@@ -69,7 +70,37 @@ bool selectItemWithData(QListWidget * a_ListWidget, const QVariant & a_Data);
 /** Returns a string that represents the data in hex. */
 QString toHex(const QByteArray & a_Data);
 
+
+
+
+
+
+/** RAII class for saving and restoring QPainter state. */
+class QPainterSaver
+{
+public:
+
+	/** Creates a new instance, saves the QPainter state. */
+	QPainterSaver(QPainter & a_Painter);
+
+	/** Creates a new instance, saves the QPainter state. */
+	QPainterSaver(QPainter * a_Painter);
+
+	/** Restores the QPainter state. */
+	~QPainterSaver();
+
+
+protected:
+
+	/** The painter whose state will be restored on exit. */
+	QPainter * m_Painter;
 };
+
+
+
+
+
+};  // namespace Utils
 
 
 

--- a/translations/SkauTan_cs.ts
+++ b/translations/SkauTan_cs.ts
@@ -3593,12 +3593,12 @@ Poslední změna: %2</translation>
 <context>
     <name>WaveformDisplay</name>
     <message>
-        <location filename="../src/UI/WaveformDisplay.cpp" line="242"/>
+        <location filename="../src/UI/WaveformDisplay.cpp" line="279"/>
         <source>Set skip-start here</source>
         <translation>Nastavit sem přeskočení</translation>
     </message>
     <message>
-        <location filename="../src/UI/WaveformDisplay.cpp" line="243"/>
+        <location filename="../src/UI/WaveformDisplay.cpp" line="280"/>
         <source>Remove skip-start</source>
         <translation>Stornovat nastavené přeskočení</translation>
     </message>

--- a/translations/SkauTan_cs.ts
+++ b/translations/SkauTan_cs.ts
@@ -2312,28 +2312,28 @@ Tato operace je nevratná!</translation>
         <translation>&amp;Zavřít</translation>
     </message>
     <message>
-        <location filename="../src/UI/Dlg/DlgTempoDetect.cpp" line="59"/>
+        <location filename="../src/UI/Dlg/DlgTempoDetect.cpp" line="61"/>
         <source>Detection in progress...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/UI/Dlg/DlgTempoDetect.cpp" line="240"/>
+        <location filename="../src/UI/Dlg/DlgTempoDetect.cpp" line="242"/>
         <source>Use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/UI/Dlg/DlgTempoDetect.cpp" line="328"/>
+        <location filename="../src/UI/Dlg/DlgTempoDetect.cpp" line="330"/>
         <source>SkauTan: Save debug audio with Beats</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/UI/Dlg/DlgTempoDetect.cpp" line="330"/>
-        <location filename="../src/UI/Dlg/DlgTempoDetect.cpp" line="351"/>
+        <location filename="../src/UI/Dlg/DlgTempoDetect.cpp" line="332"/>
+        <location filename="../src/UI/Dlg/DlgTempoDetect.cpp" line="353"/>
         <source>RAW audio file (*.raw)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/UI/Dlg/DlgTempoDetect.cpp" line="349"/>
+        <location filename="../src/UI/Dlg/DlgTempoDetect.cpp" line="351"/>
         <source>SkauTan: Save debug audio with Levels</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3593,12 +3593,12 @@ Poslední změna: %2</translation>
 <context>
     <name>WaveformDisplay</name>
     <message>
-        <location filename="../src/UI/WaveformDisplay.cpp" line="243"/>
+        <location filename="../src/UI/WaveformDisplay.cpp" line="242"/>
         <source>Set skip-start here</source>
         <translation>Nastavit sem přeskočení</translation>
     </message>
     <message>
-        <location filename="../src/UI/WaveformDisplay.cpp" line="244"/>
+        <location filename="../src/UI/WaveformDisplay.cpp" line="243"/>
         <source>Remove skip-start</source>
         <translation>Stornovat nastavené přeskočení</translation>
     </message>


### PR DESCRIPTION
Show the SkipStart and DurationLimit as different background and foreground-color in the waveform display.

Fixes #229.
Fixes #226 comment 2: refactor into generic `timeToScreen` and `screenToTime` functions.