### PR TITLE
Fix DJ Controllers

### DIFF
--- a/Experiments/FreqExtract.cpp
+++ b/Experiments/FreqExtract.cpp
@@ -4,7 +4,7 @@
 #include <QDebug>
 #include "../src/Audio/AVPP.hpp"
 #include "../src/Audio/PlaybackBuffer.hpp"
-#include "../Src/Utils.hpp"
+#include "../src/Utils.hpp"
 
 
 

--- a/src/Controller/MidiController.cpp
+++ b/src/Controller/MidiController.cpp
@@ -149,14 +149,14 @@ void SimpleMidiController::processMidiInMessage(double a_TimeStamp, const QByteA
 			auto slider = m_SliderMap.find(msgBytes[1]);
 			if (slider != m_SliderMap.end())
 			{
-				auto value = static_cast<double>(a_Message[2]) / 127;
+				auto value = static_cast<double>(msgBytes[2]) / 127;
 				emit sliderSet(slider->second, value);
 				return;
 			}
 			auto wheel = m_WheelMap.find(msgBytes[1]);
 			if (wheel != m_WheelMap.end())
 			{
-				auto numSteps = (a_Message[2] < 0x40) ? a_Message[2] : (128 - a_Message[2]);
+				auto numSteps = (msgBytes[2] < 0x40) ? msgBytes[2] : (msgBytes[2] - 128);
 				emit wheelMoved(wheel->second, numSteps);
 				return;
 			}

--- a/src/Controller/MidiEnumerator.cpp
+++ b/src/Controller/MidiEnumerator.cpp
@@ -109,27 +109,27 @@ static const struct SimpleControllerDef
 			{ 0x5a, AbstractController::skEnter1 },
 		},  // keyMap
 		{
-			{ AbstractController::slKeyCue1,       0x33 },
-			{ AbstractController::slKeyPlayPause1, 0x3b },
-			{ AbstractController::slKeySync1,      0x40 },
-			{ AbstractController::slKeyPfl1,       0x65 },
-			{ AbstractController::slKeyCue2,       0x3c },
-			{ AbstractController::slKeyPlayPause2, 0x42 },
-			{ AbstractController::slKeySync2,      0x47 },
-			{ AbstractController::slKeyPfl2,       0x66 },
+			{ 0x33, AbstractController::slKeyCue1},
+			{ 0x3b, AbstractController::slKeyPlayPause1},
+			{ 0x40, AbstractController::slKeySync1},
+			{ 0x65, AbstractController::slKeyPfl1},
+			{ 0x3c, AbstractController::slKeyCue2},
+			{ 0x42, AbstractController::slKeyPlayPause2},
+			{ 0x47, AbstractController::slKeySync2},
+			{ 0x66, AbstractController::slKeyPfl2},
 		},  // ledMap
 		{
-			{ AbstractController::ssMasterVolume, 0x17 },
-			{ AbstractController::ssVolume1,      0x08 },
-			{ AbstractController::ssVolume2,      0x09 },
-			{ AbstractController::ssCrossfade1,   0x0a },
-			{ AbstractController::ssPitch1,       0x0d },
-			{ AbstractController::ssPitch2,       0x0e },
+			{ 0x17, AbstractController::ssMasterVolume},
+			{ 0x08, AbstractController::ssVolume1},
+			{ 0x09, AbstractController::ssVolume2},
+			{ 0x0a, AbstractController::ssCrossfade1},
+			{ 0x0d, AbstractController::ssPitch1},
+			{ 0x0e, AbstractController::ssPitch2},
 		},  // sliderMap
 		{
-			{ AbstractController::swBrowse, 0x1a},
-			{ AbstractController::swJog1,   0x19 },
-			{ AbstractController::swJog2,   0x18 },
+			{ 0x1a, AbstractController::swBrowse},
+			{ 0x19, AbstractController::swJog1},
+			{ 0x18, AbstractController::swJog2},
 		},  // wheelMap
 	},  // Numark DJ2Go
 };

--- a/src/DJControllers.cpp
+++ b/src/DJControllers.cpp
@@ -96,10 +96,19 @@ void DJControllers::unregisterWheelHandler(quint64 a_RegID)
 
 
 
-DJControllers::KeyHandlerRegPtr DJControllers::registerContextKeyHandler(const QString & a_Context, DJControllers::KeyHandler a_Callback)
+DJControllers::KeyHandlerRegPtr DJControllers::registerContextKeyHandler(
+	const QString & a_Context,
+	QObject * a_DestinationObject,
+	const char * a_CallbackName
+)
 {
 	auto regID = m_NextRegID++;
-	m_KeyHandlers.push_back(std::make_tuple(regID, a_Context, a_Callback));
+	m_KeyHandlers.push_back(
+		std::make_tuple(
+			regID, a_Context,
+			Handler(a_DestinationObject, a_CallbackName)
+		)
+	);
 	return std::make_shared<KeyHandlerReg>(*this, regID);
 }
 
@@ -107,10 +116,19 @@ DJControllers::KeyHandlerRegPtr DJControllers::registerContextKeyHandler(const Q
 
 
 
-DJControllers::SliderHandlerRegPtr DJControllers::registerContextSliderHandler(const QString & a_Context, DJControllers::SliderHandler a_Callback)
+DJControllers::SliderHandlerRegPtr DJControllers::registerContextSliderHandler(
+	const QString & a_Context,
+	QObject * a_DestinationObject,
+	const char * a_CallbackName
+)
 {
 	auto regID = m_NextRegID++;
-	m_SliderHandlers.push_back(std::make_tuple(regID, a_Context, a_Callback));
+	m_SliderHandlers.push_back(
+		std::make_tuple(
+			regID, a_Context,
+			Handler(a_DestinationObject, a_CallbackName)
+		)
+	);
 	return std::make_shared<SliderHandlerReg>(*this, regID);
 }
 
@@ -118,10 +136,19 @@ DJControllers::SliderHandlerRegPtr DJControllers::registerContextSliderHandler(c
 
 
 
-DJControllers::WheelHandlerRegPtr DJControllers::registerContextWheelHandler(const QString & a_Context, DJControllers::WheelHandler a_Callback)
+DJControllers::WheelHandlerRegPtr DJControllers::registerContextWheelHandler(
+	const QString & a_Context,
+	QObject * a_DestinationObject,
+	const char * a_CallbackName
+)
 {
 	auto regID = m_NextRegID++;
-	m_WheelHandlers.push_back(std::make_tuple(regID, a_Context, a_Callback));
+	m_WheelHandlers.push_back(
+		std::make_tuple(
+			regID, a_Context,
+			Handler(a_DestinationObject, a_CallbackName)
+		)
+	);
 	return std::make_shared<WheelHandlerReg>(*this, regID);
 }
 
@@ -243,7 +270,13 @@ void DJControllers::controllerKeyPressed(int a_Key)
 	{
 		if (std::get<1>(handler) == context)
 		{
-			std::get<2>(handler)(a_Key);
+			auto & reg = std::get<2>(handler);
+			QMetaObject::invokeMethod(
+				reg.m_DestinationObject,
+				reg.m_FunctionName.c_str(),
+				Qt::QueuedConnection,
+				Q_ARG(int, a_Key)
+			);
 		}
 	}
 }
@@ -260,7 +293,14 @@ void DJControllers::controllerSliderSet(int a_Slider, qreal a_Value)
 	{
 		if (std::get<1>(handler) == context)
 		{
-			std::get<2>(handler)(a_Slider, a_Value);
+			auto & reg = std::get<2>(handler);
+			QMetaObject::invokeMethod(
+				reg.m_DestinationObject,
+				reg.m_FunctionName.c_str(),
+				Qt::QueuedConnection,
+				Q_ARG(int, a_Slider),
+				Q_ARG(qreal, a_Value)
+			);
 		}
 	}
 }
@@ -277,7 +317,14 @@ void DJControllers::controllerWheelMoved(int a_Wheel, int a_NumSteps)
 	{
 		if (std::get<1>(handler) == context)
 		{
-			std::get<2>(handler)(a_Wheel, a_NumSteps);
+			auto & reg = std::get<2>(handler);
+			QMetaObject::invokeMethod(
+				reg.m_DestinationObject,
+				reg.m_FunctionName.c_str(),
+				Qt::QueuedConnection,
+				Q_ARG(int, a_Wheel),
+				Q_ARG(int, a_NumSteps)
+			);
 		}
 	}
 }

--- a/src/DJControllers.hpp
+++ b/src/DJControllers.hpp
@@ -48,9 +48,18 @@ protected:
 
 public:
 
-	using KeyHandler = std::function<void(int a_Key)>;
-	using SliderHandler = std::function<void(int a_Slider, qreal a_Value)>;
-	using WheelHandler = std::function<void(int a_Wheel, int a_NumSteps)>;
+	/** Wrapper for the handler function name and the object on which it should be invoked. */
+	struct Handler
+	{
+		QObject * m_DestinationObject;
+		std::string m_FunctionName;
+
+		Handler(QObject * a_DestinationObject, const char * a_FunctionName):
+			m_DestinationObject(a_DestinationObject),
+			m_FunctionName(a_FunctionName)
+		{
+		}
+	};
 
 
 	/** RAII class for unregistering callbacks upon its destruction. */
@@ -104,19 +113,22 @@ public:
 	Returns a registration object that unregisters the callback when destroyed. */
 	KeyHandlerRegPtr registerContextKeyHandler(
 		const QString & a_Context,
-		KeyHandler a_Callback
+		QObject * a_Destination,
+		const char * a_CallbackName
 	);
 
 	/** Registers a handler for slider events in the specified context. */
 	SliderHandlerRegPtr registerContextSliderHandler(
 		const QString & a_Context,
-		SliderHandler a_Callback
+		QObject * a_Destination,
+		const char * a_CallbackName
 	);
 
 	/** Registers a handler for wheel events in the specified context. */
 	WheelHandlerRegPtr registerContextWheelHandler(
 		const QString & a_Context,
-		WheelHandler a_Callback
+		QObject * a_Destination,
+		const char * a_CallbackName
 	);
 
 
@@ -135,13 +147,13 @@ private:
 	std::atomic<quint64> m_NextRegID;
 
 	/** The registered key handlers. */
-	std::vector<std::tuple<quint64, QString, KeyHandler>> m_KeyHandlers;
+	std::vector<std::tuple<quint64, QString, Handler>> m_KeyHandlers;
 
 	/** The registered slider handlers. */
-	std::vector<std::tuple<quint64, QString, SliderHandler>> m_SliderHandlers;
+	std::vector<std::tuple<quint64, QString, Handler>> m_SliderHandlers;
 
 	/** The registered wheel handlers. */
-	std::vector<std::tuple<quint64, QString, WheelHandler>> m_WheelHandlers;
+	std::vector<std::tuple<quint64, QString, Handler>> m_WheelHandlers;
 
 
 	/** Sends a message to turn the specified LED on or off. */

--- a/src/UI/ClassroomWindow.cpp
+++ b/src/UI/ClassroomWindow.cpp
@@ -402,11 +402,11 @@ void ClassroomWindow::applySearchFilterToSongs()
 	m_UI->lwSongs->clear();
 	for (const auto & song: m_AllFilterSongs)
 	{
-		auto item = std::make_unique<QListWidgetItem>();
-		item->setData(Qt::UserRole, QVariant::fromValue(song->shared_from_this()));
-		updateSongItem(*item);
-		if (m_SearchFilter.match(item->text()).hasMatch())
+		if (m_SearchFilter.match(songDisplayText(*song)).hasMatch())
 		{
+			auto item = std::make_unique<QListWidgetItem>();
+			item->setData(Qt::UserRole, QVariant::fromValue(song->shared_from_this()));
+			updateSongItem(*item);
 			m_UI->lwSongs->addItem(item.release());
 		}
 	}
@@ -422,9 +422,9 @@ void ClassroomWindow::setUpDjControllers()
 	const QString CONTEXT = "ClassroomWindow";
 	setProperty(DJControllers::CONTEXT_PROPERTY_NAME, CONTEXT);
 	auto djc = m_Components.get<DJControllers>();
-	m_DjKeyHandler    = djc->registerContextKeyHandler(   CONTEXT, [this](int a_Key) { handleDjControllerKey(a_Key); });
-	m_DjSliderHandler = djc->registerContextSliderHandler(CONTEXT, [this](int a_Slider, qreal a_Value) { handleDjControllerSlider(a_Slider, a_Value); });
-	m_DjWheelHandler  = djc->registerContextWheelHandler( CONTEXT, [this](int a_Wheel, int a_NumSteps) { handleDjControllerWheel(a_Wheel, a_NumSteps); });
+	m_DjKeyHandler    = djc->registerContextKeyHandler(   CONTEXT, this, "handleDjControllerKey");
+	m_DjSliderHandler = djc->registerContextSliderHandler(CONTEXT, this, "handleDjControllerSlider");
+	m_DjWheelHandler  = djc->registerContextWheelHandler( CONTEXT, this, "handleDjControllerWheel");
 }
 
 
@@ -443,6 +443,8 @@ void ClassroomWindow::handleDjControllerKey(int a_Key)
 		}
 		case AbstractController::skEnter1:
 		case AbstractController::skEnter2:
+		case AbstractController::skCue1:
+		case AbstractController::skCue2:
 		{
 			playSelectedSong();
 			return;
@@ -699,6 +701,10 @@ void ClassroomWindow::durationLimitEdited(const QString & a_NewText)
 void ClassroomWindow::playSelectedSong()
 {
 	auto selItem = m_UI->lwSongs->currentItem();
+	if (selItem == nullptr)
+	{
+		return;
+	}
 	startPlayingSong(selItem->data(Qt::UserRole).value<SongPtr>());
 }
 

--- a/src/UI/ClassroomWindow.hpp
+++ b/src/UI/ClassroomWindow.hpp
@@ -127,6 +127,9 @@ private:
 	/** Initializes the window to accept input by DJ controllers. */
 	void setUpDjControllers();
 
+
+public slots:
+
 	/** Handler for keypresses on the DJ controller. */
 	void handleDjControllerKey(int a_Key);
 
@@ -135,14 +138,6 @@ private:
 
 	/** Handler for wheel moves on the DJ controller. */
 	void handleDjControllerWheel(int a_Wheel, int a_NumSteps);
-
-	/** Moves the selection in lwFilters by the specified number of steps up or down.
-	If not all steps can be taken, they are ignored silently. */
-	void moveFilterSelection(int a_NumSteps);
-
-	/** Moves the selection in lwSongs by the specified number of steps up or down.
-	If not all steps can be taken, they are ignored silently. */
-	void moveSongSelection(int a_NumSteps);
 
 
 private slots:

--- a/src/UI/PlayerWindow.cpp
+++ b/src/UI/PlayerWindow.cpp
@@ -387,9 +387,9 @@ void PlayerWindow::setUpDjControllers()
 	const QString CONTEXT = "PlayerWindow";
 	setProperty(DJControllers::CONTEXT_PROPERTY_NAME, CONTEXT);
 	auto djc = m_Components.get<DJControllers>();
-	m_DjKeyHandler    = djc->registerContextKeyHandler(   CONTEXT, [this](int a_Key) { handleDjControllerKey(a_Key); });
-	m_DjSliderHandler = djc->registerContextSliderHandler(CONTEXT, [this](int a_Slider, qreal a_Value) { handleDjControllerSlider(a_Slider, a_Value); });
-	m_DjWheelHandler  = djc->registerContextWheelHandler( CONTEXT, [this](int a_Wheel, int a_NumSteps) { handleDjControllerWheel(a_Wheel, a_NumSteps); });
+	m_DjKeyHandler    = djc->registerContextKeyHandler(   CONTEXT, this, "handleDjControllerKey");
+	m_DjSliderHandler = djc->registerContextSliderHandler(CONTEXT, this, "handleDjControllerSlider");
+	m_DjWheelHandler  = djc->registerContextWheelHandler( CONTEXT, this, "handleDjControllerWheel");
 }
 
 

--- a/src/UI/PlayerWindow.hpp
+++ b/src/UI/PlayerWindow.hpp
@@ -115,6 +115,9 @@ private:
 	/** Sets up all that is needed to support the DJ controllers in this window. */
 	void setUpDjControllers();
 
+
+public slots:
+
 	/** Handler for keypresses on the DJ controller. */
 	void handleDjControllerKey(int a_Key);
 

--- a/translations/SkauTan_cs.ts
+++ b/translations/SkauTan_cs.ts
@@ -184,17 +184,17 @@
         <translation>Zrovna přehráváno: %1</translation>
     </message>
     <message>
-        <location filename="../src/UI/ClassroomWindow.cpp" line="732"/>
+        <location filename="../src/UI/ClassroomWindow.cpp" line="738"/>
         <source>SkauTan: Remove song?</source>
         <translation>SkauTan: Odebrat skladbu?</translation>
     </message>
     <message>
-        <location filename="../src/UI/ClassroomWindow.cpp" line="778"/>
+        <location filename="../src/UI/ClassroomWindow.cpp" line="784"/>
         <source>SkauTan: Delete song?</source>
         <translation>SkauTan: Vymazat skladbu?</translation>
     </message>
     <message>
-        <location filename="../src/UI/ClassroomWindow.cpp" line="733"/>
+        <location filename="../src/UI/ClassroomWindow.cpp" line="739"/>
         <source>Are you sure you want to remove the selected song from the library? The song file will stay on the disk, but all properties set in the library will be lost.
 
 This operation cannot be undone!</source>
@@ -203,7 +203,7 @@ This operation cannot be undone!</source>
 Tato operace je nevratná!</translation>
     </message>
     <message>
-        <location filename="../src/UI/ClassroomWindow.cpp" line="779"/>
+        <location filename="../src/UI/ClassroomWindow.cpp" line="785"/>
         <source>Are you sure you want to delete the selected song from the disk?The files will be deleted and all properties set in the library will be lost.
 
 This operation cannot be undone!</source>


### PR DESCRIPTION
The DJ2Go controller didn't work when last tested, borrowed it again and fixed the implementation.

Two issues fixed:
- the definition was backwards
- threading issues (handler in non-UI thread touching UI elements)